### PR TITLE
package.json: use ${workspaceRoot}

### DIFF
--- a/package.json
+++ b/package.json
@@ -51,7 +51,7 @@
             "name": "Launch index.html",
             "type": "chrome",
             "request": "launch",
-            "file": "index.html"
+            "file": "${workspaceRoot}/index.html"
           },
           {
             "name": "Launch localhost with sourcemaps",


### PR DESCRIPTION
This should only be merged in when the VSCode january update is out due to this issue https://github.com/Microsoft/vscode/issues/1180

At the moment we magically append the workspace root to some properties of the launch.json on the vscode side.
This will go away in the future since it is clunky. Thus we want to educate users to use the ${workspaceRoot} variable for all paths, since we will no longer support relative paths in the future.