### PR TITLE
Fixing an uncaught exception with misbehaved stack frames

### DIFF
--- a/webkit/webKitDebugAdapter.ts
+++ b/webkit/webKitDebugAdapter.ts
@@ -431,31 +431,43 @@ export class WebKitDebugAdapter implements IDebugAdapter {
                 const line = callFrame.location.lineNumber;
                 const column = callFrame.location.columnNumber;
 
-                // When the script has a url and isn't a content script, send the name and path fields. PathTransformer will
-                // attempt to resolve it to a script in the workspace. Otherwise, send the name and sourceReference fields.
-                const source: DebugProtocol.Source =
-                    script.url && !this.isExtensionScript(script) ?
-                        {
-                            name: path.basename(script.url),
-                            path: script.url,
-                            sourceReference: scriptIdToSourceReference(script.scriptId) // will be 0'd out by PathTransformer if not needed
-                        } :
-                        {
-                            // Name should be undefined, work around VS Code bug 20274
-                            name: 'eval: ' + script.scriptId,
-                            sourceReference: scriptIdToSourceReference(script.scriptId)
-                        };
+                try {
+                    // When the script has a url and isn't a content script, send the name and path fields. PathTransformer will
+                    // attempt to resolve it to a script in the workspace. Otherwise, send the name and sourceReference fields.
+                    const source: DebugProtocol.Source =
+                        script.url && !this.isExtensionScript(script) ?
+                            {
+                                name: path.basename(script.url),
+                                path: script.url,
+                                sourceReference: scriptIdToSourceReference(script.scriptId) // will be 0'd out by PathTransformer if not needed
+                            } :
+                            {
+                                // Name should be undefined, work around VS Code bug 20274
+                                name: 'eval: ' + script.scriptId,
+                                sourceReference: scriptIdToSourceReference(script.scriptId)
+                            };
 
-                // If the frame doesn't have a function name, it's either an anonymous function
-                // or eval script. If its source has a name, it's probably an anonymous function.
-                const frameName = callFrame.functionName || (script.url ? '(anonymous function)' : '(eval code)');
-                return {
-                    id: i,
-                    name: frameName,
-                    source,
-                    line: line,
-                    column
-                };
+                    // If the frame doesn't have a function name, it's either an anonymous function
+                    // or eval script. If its source has a name, it's probably an anonymous function.
+                    const frameName = callFrame.functionName || (script.url ? '(anonymous function)' : '(eval code)');
+                    return {
+                        id: i,
+                        name: frameName,
+                        source,
+                        line: line,
+                        column
+                    };
+                } catch (e) {
+                    // Some targets such as the iOS simulator behave badly and return nonsense callFrames.
+                    // In these cases, return a dummy stack frame
+                    return {
+                        id: i,
+                        name: 'Unknown',
+                        source: {name: 'eval:Unknown'},
+                        line,
+                        column
+                    };
+                }
             });
 
         return { stackFrames };


### PR DESCRIPTION
Some targets (I encountered this on an iOS emulator) include invalid stack frames which would cause an exception to be thrown, and this would cause issues for VS code. With this fix we replace these stack frames with 'Unknown' and otherwise continue working.

Another alternative would be to exclude these stack frames from the response, though I'm not sure whether that is a better outcome.