### PR TITLE
Expanding accepted browser responses for interactive errors

### DIFF
--- a/webkit/webKitDebugAdapter.ts
+++ b/webkit/webKitDebugAdapter.ts
@@ -545,7 +545,13 @@ export class WebKitDebugAdapter implements IDebugAdapter {
 
         return evalPromise.then(evalResponse => {
             if (evalResponse.result.wasThrown) {
-                const errorMessage = evalResponse.result.exceptionDetails ? evalResponse.result.exceptionDetails.text : 'Error';
+                const evalResult = evalResponse.result;
+                let errorMessage: string = 'Error';
+                if (evalResult.exceptionDetails) {
+                    errorMessage = evalResult.exceptionDetails.text;
+                } else if (evalResult.result && evalResult.result.description) {
+                    errorMessage = evalResult.result.description;
+                }
                 return utils.errP(errorMessage);
             }
 


### PR DESCRIPTION
When evaluating scripts entered on the javascript console, the extension currently expects to get a response with a `result.exceptionDetails.text` property. However some targets, such as the Android and iOS webviews, respond with a `result.result.description` (yes, two results) property. With this fix it checks for both.