### PR TITLE
Adding the option to specify your custom path for the sourcemap file 

### DIFF
--- a/adapter/sourceMaps/sourceMapTransformer.ts
+++ b/adapter/sourceMaps/sourceMapTransformer.ts
@@ -25,7 +25,7 @@ export class SourceMapTransformer implements IDebugTransformer {
     private _webRoot: string;
     private _authoredPathsToMappedBPLines: Map<string, number[]>;
     private _authoredPathsToMappedBPCols: Map<string, number[]>;
-    private _externalSourceMapPath : string;
+    private _externalSourceMapPath: string;
 
     public launch(args: ILaunchRequestArgs): void {
         this.init(args);
@@ -201,7 +201,7 @@ export class SourceMapTransformer implements IDebugTransformer {
             }
 
             // Prefers the external sourceMapUrl over the one defined in the body
-            let sourceMapUrl : string;
+            let sourceMapUrl: string;
             sourceMapUrl = this._externalSourceMapPath || event.body.sourceMapURL;
 
             this._sourceMaps.ProcessNewSourceMap(event.body.scriptUrl, sourceMapUrl).then(() => {

--- a/adapter/sourceMaps/sourceMapTransformer.ts
+++ b/adapter/sourceMaps/sourceMapTransformer.ts
@@ -25,6 +25,7 @@ export class SourceMapTransformer implements IDebugTransformer {
     private _webRoot: string;
     private _authoredPathsToMappedBPLines: Map<string, number[]>;
     private _authoredPathsToMappedBPCols: Map<string, number[]>;
+    private _externalSourceMapPath : string;
 
     public launch(args: ILaunchRequestArgs): void {
         this.init(args);
@@ -42,6 +43,7 @@ export class SourceMapTransformer implements IDebugTransformer {
             this._allRuntimeScriptPaths = new Set<string>();
             this._authoredPathsToMappedBPLines = new Map<string, number[]>();
             this._authoredPathsToMappedBPCols = new Map<string, number[]>();
+            this._externalSourceMapPath = args.externalSourceMapPath;
         }
     }
 
@@ -198,7 +200,11 @@ export class SourceMapTransformer implements IDebugTransformer {
                 return;
             }
 
-            this._sourceMaps.ProcessNewSourceMap(event.body.scriptUrl, event.body.sourceMapURL).then(() => {
+            // Prefers the external sourceMapUrl over the one defined in the body
+            let sourceMapUrl : string;
+            sourceMapUrl = this._externalSourceMapPath || event.body.sourceMapURL;
+
+            this._sourceMaps.ProcessNewSourceMap(event.body.scriptUrl, sourceMapUrl).then(() => {
                 const sources = this._sourceMaps.AllMappedSources(event.body.scriptUrl);
                 if (sources) {
                     utils.Logger.log(`SourceMaps.scriptParsed: ${event.body.scriptUrl} was just loaded and has mapped sources: ${JSON.stringify(sources) }`);

--- a/package.json
+++ b/package.json
@@ -125,6 +125,11 @@
                 "type": "string",
                 "description": "When set, Chrome is launched with the --user-data-dir option set to this path",
                 "default": ""
+              },
+              "externalSourceMapPath" :{
+                "type": "string",
+                "description": "When set, vscode will use it for the sourcemaps file",
+                "default": ""
               }
             }
           },
@@ -157,6 +162,11 @@
                 "type": "string",
                 "description": "When the 'url' field is specified, this specifies the workspace relative or absolute path to the webserver root.",
                 "default": "."
+              },
+              "externalSourceMapPath" :{
+                "type": "string",
+                "description": "When set, vscode will use it for the sourcemaps file",
+                "default": ""
               }
             }
           }

--- a/webkit/utilities.ts
+++ b/webkit/utilities.ts
@@ -382,6 +382,7 @@ export function getURL(aUrl: string): Promise<string> {
                 if (response.statusCode === 200) {
                     resolve(responseData);
                 } else {
+                    Logger.log('Http Get failed with: ' + response.statusCode.toString() + ' ' + response.statusMessage.toString());
                     reject(responseData);
                 }
             });

--- a/webkit/webKitAdapterInterfaces.d.ts
+++ b/webkit/webKitAdapterInterfaces.d.ts
@@ -10,6 +10,7 @@ interface ILaunchRequestArgs extends DebugProtocol.LaunchRequestArguments {
     port?: number;
     diagnosticLogging?: boolean;
     userDataDir?: string;
+    externalSourceMapPath?: string;
 }
 
 interface IAttachRequestArgs extends DebugProtocol.AttachRequestArguments {
@@ -18,6 +19,7 @@ interface IAttachRequestArgs extends DebugProtocol.AttachRequestArguments {
     port: number;
     sourceMaps?: boolean;
     diagnosticLogging?: boolean;
+    externalSourceMapPath?: string;
 }
 
 interface ISetBreakpointsArgs extends DebugProtocol.SetBreakpointsArguments {


### PR DESCRIPTION
Adding the option to specify your custom path for the sourcemap file to workaround problems when the extension can't download it automatically.
Adding logging for the http failures in the getUrl utility