### PR TITLE
Logging http status and message for getUrl failure

### DIFF
--- a/webkit/utilities.ts
+++ b/webkit/utilities.ts
@@ -382,6 +382,7 @@ export function getURL(aUrl: string): Promise<string> {
                 if (response.statusCode === 200) {
                     resolve(responseData);
                 } else {
+                    Logger.log('Http Get failed with: ' + response.statusCode.toString() + ' ' + response.statusMessage.toString());
                     reject(responseData);
                 }
             });


### PR DESCRIPTION
Logging http status and message for getUrl when statuscode is different than 200 (OK), helps to diagnose problems with the debugger extension