### PR TITLE
add path mapping

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,7 +96,10 @@ An example `launch.json` config.
             "type": "chrome",
             "request": "attach",
             "port": 9222,
-            "url": "<url of the open browser tab to connect to>"
+            "url": "<url of the open browser tab to connect to>",
+            "pathMapping": {
+              "/": "${workspaceRoot}"
+            }
         },
         {
             "name": "Attach to url with files served from ./out",
@@ -104,7 +107,9 @@ An example `launch.json` config.
             "request": "attach",
             "port": 9222,
             "url": "<url of the open browser tab to connect to>",
-            "webRoot": "${workspaceRoot}/out"
+            "pathMapping": {
+              "/": "${workspaceRoot}"
+            }
         }
     ]
 }
@@ -125,8 +130,8 @@ See our wiki page for some configured example apps: [Examples](https://github.co
 * `url`: Required for a 'launch' config. For an attach config, the debugger will search for a tab that has that URL. It can also contain wildcards, for example, `"localhost:*/app"` will match either `"http://localhost:123/app"` or `"http://localhost:456/app"`, but not `"http://stackoverflow.com"`.
 * `sourceMaps`: By default, the adapter will use sourcemaps and your original sources whenever possible. You can disable this by setting `sourceMaps` to false.
 
-## Skip files / Blackboxing / Ignore files 
-You can use the `skipFiles` property to ignore/blackbox specific files while debugging. For example, if you set `"skipFiles": ["jquery.js"]`, then you will skip any file named 'jquery.js' when stepping through your code. You also won't break on exceptions thrown from 'jquery.js'. This works the same as "blackboxing scripts" in Chrome DevTools. 
+## Skip files / Blackboxing / Ignore files
+You can use the `skipFiles` property to ignore/blackbox specific files while debugging. For example, if you set `"skipFiles": ["jquery.js"]`, then you will skip any file named 'jquery.js' when stepping through your code. You also won't break on exceptions thrown from 'jquery.js'. This works the same as "blackboxing scripts" in Chrome DevTools.
 
 The supported formats are:
   * The name of a file (like `jquery.js`)
@@ -146,7 +151,7 @@ This debugger also enables you to refresh your target by simply hitting the `res
 Read more here https://github.com/Microsoft/vscode-chrome-debug-core/issues/91#issuecomment-265027348
 
 ## Sourcemaps
-The debugger relies heavly on sourcemaps, but sometimes the sourcemaps aren't generated properly and overrides are needed. In the config we support `sourceMapPathOverrides`. A mapping of source paths from the sourcemap, to the locations of these sources on disk. Useful when the sourcemap isn't accurate or can't be fixed in the build process. 
+The debugger relies heavly on sourcemaps, but sometimes the sourcemaps aren't generated properly and overrides are needed. In the config we support `sourceMapPathOverrides`. A mapping of source paths from the sourcemap, to the locations of these sources on disk. Useful when the sourcemap isn't accurate or can't be fixed in the build process.
 
 The left hand side of the mapping is a pattern that can contain a wildcard, and will be tested against the `sourceRoot` + `sources` entry in the source map. If it matches, the source file will be resolved to the path on the right hand side, which should be an absolute path to the source file on disk.
 

--- a/package.json
+++ b/package.json
@@ -84,14 +84,18 @@
             "type": "chrome",
             "request": "launch",
             "url": "http://localhost:8080",
-            "webRoot": "${workspaceRoot}"
+            "pathMapping": {
+              "/": "${workspaceRoot}"
+            }
           },
           {
             "name": "Attach to Chrome",
             "type": "chrome",
             "request": "attach",
             "port": 9222,
-            "webRoot": "${workspaceRoot}"
+            "pathMapping": {
+              "/": "${workspaceRoot}"
+            }
           }
         ],
         "configurationAttributes": {
@@ -122,6 +126,11 @@
                 "type": "string",
                 "description": "When the 'url' field is specified, this specifies the workspace absolute path to the webserver root.",
                 "default": "${workspaceRoot}"
+              },
+              "pathMapping": {
+                "type": "object",
+                "description": "Map url (key) to a local folder (value)",
+                "default": {}
               },
               "runtimeExecutable": {
                 "type": [
@@ -215,6 +224,11 @@
                 "type": "string",
                 "description": "This specifies the workspace absolute path to the webserver root. Used to resolve paths like `/app.js` to files on disk.",
                 "default": "${workspaceRoot}"
+              },
+              "pathMapping": {
+                "type": "object",
+                "description": "Map url (key) to a local folder (value)",
+                "default": {}
               },
               "sourceMapPathOverrides": {
                 "type": "object",


### PR DESCRIPTION
Hi @roblourens,
it fixes Microsoft/vscode-chrome-debug-core#146.
I added pathMapping in the launcher config:
So it replace webRoot and sourceMapPathOverrides that are no longer needed to configure a launcher
I've tested with some typescript and sourcemap and it seems to work fine with just a pathMapping.

It was tricky to configure the debug environment but I finally installed projects and found the right procedure for launching.

