### PR TITLE
Use double quotes consistently in npm scripts.

### DIFF
--- a/package.json
+++ b/package.json
@@ -56,9 +56,9 @@
     "watch": "concurrently \"npm run watch:debugadapter\" \"npm run watch:test\"",
     "watch:debugadapter": "webpack -w",
     "watch:test": "tsc -p test/tsconfig.json -w",
-    "test": "mocha --timeout 20000 -s 2000 -u tdd --colors './out/test/*.test.js'",
+    "test": "mocha --timeout 20000 -s 2000 -u tdd --colors \"./out/test/*.test.js\"",
     "intTest": "mocha --timeout 20000 -s 3500 -u tdd --colors --reporter out/test/int/loggingReporter.js ./out/test/int/*.test.js",
-    "lint": "tslint -t verbose 'src/**/*.ts'",
+    "lint": "tslint -t verbose \"src/**/*.ts\"",
     "vscode:prepublish": "gulp verify-no-linked-modules",
     "postinstall": "node ./node_modules/vscode/bin/install"
   },


### PR DESCRIPTION
While I've been trying to debug my configuration I found out that test won't work on Windows machines.

The reason was quoting in package.json. When having apostrophe/single quote used in Windows it passes it directly to the commandline, ending up with wrong arguments.

Repro steps:

1. Clone repo on Windows machine.
1. Open cmd.exe command line in cloned directory.
1. Install deps.
1. Build js files.
1. Run `npm test`.


All tests pass.


No test files are found.