### PR TITLE
Fix chrome session restore promt in Windows

### DIFF
--- a/src/chromeDebugAdapter.ts
+++ b/src/chromeDebugAdapter.ts
@@ -217,13 +217,13 @@ export class ChromeDebugAdapter extends CoreDebugAdapter {
                     // Can fail if Chrome was already open, and the process with _chromePID is gone.
                     // Or if it already shut down for some reason.
                 }
-                if (!this._hasTerminated) {
-                    taskkillCmd = `taskkill /F /PID ${this._chromePID}`;
-                    logger.log(`Killing Chrome process by pid: ${taskkillCmd}`);
-                    try {
-                        execSync(taskkillCmd);
-                    } catch (e) {}
-                }
+                // execSync above may succeed, but Chrome still might not shut down, for example if the web page promts the user about unsaved changes.
+                // In that case, we need to use /F to force shutdown, but we risk Chrome not shutting down correctly.
+                taskkillCmd = `taskkill /F /PID ${this._chromePID}`;
+                logger.log(`Killing Chrome process by pid (using force in case the first attempt failed): ${taskkillCmd}`);
+                try {
+                    execSync(taskkillCmd);
+                } catch (e) {}
             } else {
                 logger.log('Killing Chrome process');
                 this._chromeProc.kill('SIGINT');

--- a/src/chromeDebugAdapter.ts
+++ b/src/chromeDebugAdapter.ts
@@ -211,6 +211,7 @@ export class ChromeDebugAdapter extends CoreDebugAdapter {
                 let taskkillCmd = `taskkill /PID ${this._chromePID}`;
                 logger.log(`Killing Chrome process by pid: ${taskkillCmd}`);
                 try {
+                    // Run synchronously because this process may be killed before exec() would run
                     execSync(taskkillCmd);
                 } catch (e) {
                     // Can fail if Chrome was already open, and the process with _chromePID is gone.

--- a/src/chromeDebugAdapter.ts
+++ b/src/chromeDebugAdapter.ts
@@ -201,6 +201,8 @@ export class ChromeDebugAdapter extends CoreDebugAdapter {
     public disconnect(args: DebugProtocol.DisconnectArguments): void {
         const hadTerminated = this._hasTerminated;
 
+        // Continue execution, otherwise when we kill the process it will complain that it didn't shut down correctly
+        this.continue(true);
         // Disconnect before killing Chrome, because running "taskkill" when it's paused sometimes doesn't kill it
         super.disconnect(args);
 


### PR DESCRIPTION
Fixes #416.

My first approach (call `continue()` before killing chrome) didn't work. Sometimes the issue happens even when the debugger isn't paused.

My solution is to start by killing chrome more gracefully using `taskkill /PID ${this._chromePID}`. However this won't always kill chrome - if chrome prompts the user upon closing (e.g. via `onbeforeunload`), then chrome won't close. So in case the original kill command doesn't work, we send a follow-up command with the `/F` parameter to force kill.

If we end up needing to force kill, then the session restore bubble will sometimes still appear. But at least it happens much less frequently.

Note: I removed the `/T` parameter. `taskkill /T /PID ${this._chromePID}` doesn't work - I get this console output: 

```
SUCCESS: Sent termination signal to process with PID 7020, child of PID 17760.
SUCCESS: Sent termination signal to process with PID 16576, child of PID 17760.
ERROR: The process with PID 8320 (child process of PID 17760) could not be terminated.
Reason: This process can only be terminated forcefully (with /F option).
ERROR: The process with PID 1180 (child process of PID 17760) could not be terminated.
Reason: This process can only be terminated forcefully (with /F option).
ERROR: The process with PID 17760 (child process of PID 18168) could not be terminated.
Reason: One or more child processes of this process were still running.
```

Apparently certain child processes can only be terminated with `/F` (possibly including the debugger process itself). But removing the `/T` option works.