### PR TITLE
Implements setExpression request.

### DIFF
--- a/src/chromeDebugAdapter.ts
+++ b/src/chromeDebugAdapter.ts
@@ -11,7 +11,7 @@ import {spawn, ChildProcess, fork, execSync} from 'child_process';
 import {Crdp} from 'vscode-chrome-debug-core';
 import {DebugProtocol} from 'vscode-debugprotocol';
 
-import {ILaunchRequestArgs, IAttachRequestArgs, ICommonRequestArgs} from './chromeDebugInterfaces';
+import {ILaunchRequestArgs, IAttachRequestArgs, ICommonRequestArgs, ISetExpressionArgs, VSDebugProtocolCapabilities, ISetExpressionResponseBody} from './chromeDebugInterfaces';
 import * as utils from './utils';
 import * as errors from './errors';
 
@@ -35,10 +35,11 @@ export class ChromeDebugAdapter extends CoreDebugAdapter {
     private _chromePID: number;
     private _userRequestedUrl: string;
 
-    public initialize(args: DebugProtocol.InitializeRequestArguments): DebugProtocol.Capabilities {
+    public initialize(args: DebugProtocol.InitializeRequestArguments): VSDebugProtocolCapabilities {
         this._overlayHelper = new utils.DebounceHelper(/*timeoutMs=*/200);
-        const capabilities = super.initialize(args);
+        const capabilities: VSDebugProtocolCapabilities = super.initialize(args);
         capabilities.supportsRestartRequest = true;
+        capabilities.supportsSetExpression = true;
 
         return capabilities;
     }
@@ -294,6 +295,27 @@ export class ChromeDebugAdapter extends CoreDebugAdapter {
             return chromeProc;
         }
     }
+
+    public async setExpression(args: ISetExpressionArgs): Promise<ISetExpressionResponseBody> {
+        const reconstructedExpression = `${args.expression} = ${args.value}`;
+        const evaluateEventArgs: DebugProtocol.EvaluateArguments = {
+            expression: reconstructedExpression,
+            frameId: args.frameId,
+            format: args.format,
+            context: 'repl'
+        }
+
+        const evaluateResult = await this.evaluate(evaluateEventArgs);
+        return {
+            value: evaluateResult.result
+        };
+        // Beware that after the expression is changed, the variables on the current stackFrame will not
+        // be updated, which means the return value of the Runtime.getProperties request will not contain
+        // this change until the breakpoint is released(step over or continue).
+        //
+        // See also: https://bugs.chromium.org/p/chromium/issues/detail?id=820535
+    }
+
 }
 
 function getSourceMapPathOverrides(webRoot: string, sourceMapPathOverrides?: ISourceMapPathOverrides): ISourceMapPathOverrides {

--- a/src/chromeDebugInterfaces.d.ts
+++ b/src/chromeDebugInterfaces.d.ts
@@ -3,6 +3,7 @@
  *--------------------------------------------------------*/
 
 import * as Core from 'vscode-chrome-debug-core';
+import {DebugProtocol} from 'vscode-debugprotocol';
 
 export interface ICommonRequestArgs extends Core.ICommonRequestArgs {
     disableNetworkCache?: boolean;
@@ -25,4 +26,20 @@ export interface ILaunchRequestArgs extends Core.ILaunchRequestArgs, ICommonRequ
 }
 
 export interface IAttachRequestArgs extends Core.IAttachRequestArgs, ICommonRequestArgs {
+}
+
+export interface ISetExpressionArgs {
+    expression: string;
+    value: string;
+    frameId: number;
+    format?: DebugProtocol.ValueFormat
+    timeout?: number;
+}
+
+export interface ISetExpressionResponseBody {
+    value: string;
+}
+
+export interface VSDebugProtocolCapabilities extends DebugProtocol.Capabilities {
+    supportsSetExpression?: boolean;
 }


### PR DESCRIPTION
setExpression is emitted by Visual Studio to change a value of a watch variable. Such request is out of the definition of VSCode debug protocol.

In this PR we implement only for Chrome. It is what we have verified working. Other debug adapter might need a different approach to update the value.

We want to release this change for Chrome first, because after we switch to PZ, we will have a regression of functionality unless we implement this code change. So we do want to release this piece asap. 

I will spend more time to investigate whether the same approach of updating an expression will work the same for Edge. If it can work in the same way, I will take care of moving this code to vscode-chrome-debug-core as well.
