### PR TITLE
Use landing page even if breakonload is disabled

### DIFF
--- a/src/chromeDebugAdapter.ts
+++ b/src/chromeDebugAdapter.ts
@@ -101,12 +101,11 @@ export class ChromeDebugAdapter extends CoreDebugAdapter {
             }
 
             if (launchUrl) {
-                if (this.breakOnLoadActive) {
-                    // We store the launch file/url provided and temporarily launch and attach to about:blank page. Once we receive configurationDone() event, we redirect the page to this file/url
-                    // This is done to facilitate hitting breakpoints on load
-                    this._userRequestedUrl = launchUrl;
-                    launchUrl = "about:blank";
-                }
+
+                // We store the launch file/url provided and temporarily launch and attach to about:blank page. Once we receive configurationDone() event, we redirect the page to this file/url
+                // This is done to facilitate hitting breakpoints on load
+                this._userRequestedUrl = launchUrl;
+                launchUrl = "about:blank";
 
                 chromeArgs.push(launchUrl);
             }
@@ -132,7 +131,7 @@ export class ChromeDebugAdapter extends CoreDebugAdapter {
     }
 
     public configurationDone(): Promise<void> {
-        if (this.breakOnLoadActive && this._userRequestedUrl) {
+        if (this._userRequestedUrl) {
             // This means all the setBreakpoints requests have been completed. So we can navigate to the original file/url.
             this.chrome.Page.navigate({ url: this._userRequestedUrl });
         }

--- a/test/chromeDebugAdapter.test.ts
+++ b/test/chromeDebugAdapter.test.ts
@@ -89,7 +89,7 @@ suite('ChromeDebugAdapter', () => {
             function spawn(chromePath: string, args: string[]): any {
                 assert(chromePath.toLowerCase().indexOf('chrome') >= 0);
                 assert(args.indexOf('--remote-debugging-port=9222') >= 0);
-                assert(args.indexOf('file:///c:/path%20with%20space/index.html') >= 0);
+                assert(args.indexOf('about:blank') >= 0); // Now we use the landing page for all scenarios
                 assert(args.indexOf('abc') >= 0);
                 assert(args.indexOf('def') >= 0);
                 spawnCalled = true;


### PR DESCRIPTION
As Diego mentioned in the comment, this is required to avoid the race condition during redirections inside VS:
Some web-pages redirect very fast to other web-pages etc... You go to localhost:1234/index.htm and you immediately get redirected to localhost:1234/login.htm
When that happens, chrome-core won't be able to find the url in the list of targets supplied by chrome, and it will fail... If we use the landing page we avoid this race condition