### PR TITLE
Adding signing msbuild files

### DIFF
--- a/msbuild/ChromeDebugAdapter.csproj
+++ b/msbuild/ChromeDebugAdapter.csproj
@@ -1,0 +1,49 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>netcoreapp2.0</TargetFramework>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ImagesToCopy Include="..\images\**\*" />
+    <NodeModulesToCopy Include="..\node_modules\**\*" />
+    <SrcToCopy Include="..\out\src\**\*" />
+    <RootFilesToCopy Include="..\.gitignore;..\.travis.yml;..\appveyor.yml;..\ISSUE_TEMPLATE.md;..\CHANGELOG.md;..\CONTRIBUTING.md;..\LICENSE.txt;..\package.json;..\package.nls.de.json;..\package.nls.es.json;..\package.nls.fr.json;..\package.nls.it.json;..\package.nls.ja.json;..\package.nls.json;..\package.nls.ko.json;..\package.nls.ru.json;..\package.nls.zh-cn.json;..\package.nls.zh-tw.json;..\README.md;..\ThirdPartyNotices.txt" />
+  </ItemGroup>
+
+  <Target Name="CopyFilesToSign" BeforeTargets="GetFilesToSign">
+    <Copy SourceFiles="@(ImagesToCopy)"
+          DestinationFiles="@(ImagesToCopy->'$(OutDir)\images\%(RecursiveDir)%(Filename)%(Extension)')" />
+    <Copy SourceFiles="@(NodeModulesToCopy)" 
+          DestinationFiles="@(NodeModulesToCopy->'$(OutDir)\node_modules\%(RecursiveDir)%(Filename)%(Extension)')" />
+    <Copy SourceFiles="@(SrcToCopy)"
+          DestinationFiles="@(SrcToCopy->'$(OutDir)\out\src\%(RecursiveDir)%(Filename)%(Extension)')" />
+    <Copy SourceFiles="@(RootFilesToCopy)"
+          DestinationFolder="$(OutDir)" />
+  </Target>
+
+  <Target Name="GetFilesToSign" DependsOnTargets="CopyFilesToSign" BeforeTargets="SignFiles">
+    <ItemGroup>
+      <FilesToSign Include="$(OutDir)\**\*.js" />
+      <!--<FilesToSign Include="$(OutDir)\**\*.js" Exclude="$(OutDir)\node_modules\globule\test\fixtures\expand\js\foo.js;
+                                                        $(OutDir)\node_modules\globule\test\fixtures\expand\js\bar.js;
+                                                        $(OutDir)\node_modules\resolve\test\resolver\other_path\root.js;
+                                                        $(OutDir)\node_modules\resolve\test\pathfilter\deep_ref\main.js;
+                                                        $(OutDir)\node_modules\resolve\test\resolver\baz\doom.js;
+                                                        $(OutDir)\node_modules\union\test\helpers\index.js;
+                                                        $(OutDir)\node_modules\vsce\node_modules\tmp\test\symlinkme\file.js;
+                                                        $(OutDir)\node_modules\resolve\test\resolver\mug.js;
+                                                        $(OutDir)\node_modules\resolve\test\resolver\other_path\lib\other-lib.js;
+                                                        $(OutDir)\node_modules\union\test\fixtures\index.js;" /> -->
+        <Authenticode>Microsoft400</Authenticode>
+      </FilesToSign>
+    </ItemGroup>
+  </Target>
+
+  <ItemGroup>
+    <PackageReference Include="MicroBuild.Core">
+      <Version>0.2.0</Version>
+    </PackageReference>
+  </ItemGroup>
+
+</Project>

--- a/msbuild/ChromeDebugAdapter.csproj
+++ b/msbuild/ChromeDebugAdapter.csproj
@@ -24,17 +24,15 @@
 
   <Target Name="GetFilesToSign" DependsOnTargets="CopyFilesToSign" BeforeTargets="SignFiles">
     <ItemGroup>
-      <FilesToSign Include="$(OutDir)\**\*.js">
-      <!--<FilesToSign Include="$(OutDir)\**\*.js" Exclude="$(OutDir)\node_modules\globule\test\fixtures\expand\js\foo.js;
+      <FilesToSign Include="$(OutDir)\**\*.js" Exclude="$(OutDir)\node_modules\globule\test\fixtures\expand\js\foo.js;
                                                         $(OutDir)\node_modules\globule\test\fixtures\expand\js\bar.js;
-                                                        $(OutDir)\node_modules\resolve\test\resolver\other_path\root.js;
+                                                        $(OutDir)\node_modules\resolve\test\resolver\mug.js;
                                                         $(OutDir)\node_modules\resolve\test\pathfilter\deep_ref\main.js;
                                                         $(OutDir)\node_modules\resolve\test\resolver\baz\doom.js;
-                                                        $(OutDir)\node_modules\union\test\helpers\index.js;
-                                                        $(OutDir)\node_modules\vsce\node_modules\tmp\test\symlinkme\file.js;
-                                                        $(OutDir)\node_modules\resolve\test\resolver\mug.js;
+                                                        $(OutDir)\node_modules\vsce\node_modules\vsce\node_modules\tmp\test\symlinkme\file.js;
                                                         $(OutDir)\node_modules\resolve\test\resolver\other_path\lib\other-lib.js;
-                                                        $(OutDir)\node_modules\union\test\fixtures\index.js;"> -->
+                                                        $(OutDir)\node_modules\resolve\test\resolver\other_path\root.js;
+                                                        $(OutDir)\node_modules\union\test\helpers\index.js;">
         <Authenticode>Microsoft400</Authenticode>
       </FilesToSign>
     </ItemGroup>

--- a/msbuild/ChromeDebugAdapter.csproj
+++ b/msbuild/ChromeDebugAdapter.csproj
@@ -29,9 +29,10 @@
                                                         $(OutDir)\node_modules\resolve\test\resolver\mug.js;
                                                         $(OutDir)\node_modules\resolve\test\pathfilter\deep_ref\main.js;
                                                         $(OutDir)\node_modules\resolve\test\resolver\baz\doom.js;
-                                                        $(OutDir)\node_modules\vsce\node_modules\vsce\node_modules\tmp\test\symlinkme\file.js;
+                                                        $(OutDir)\node_modules\node_modules\vsce\node_modules\tmp\test\symlinkme\file.js;
                                                         $(OutDir)\node_modules\resolve\test\resolver\other_path\lib\other-lib.js;
                                                         $(OutDir)\node_modules\resolve\test\resolver\other_path\root.js;
+                                                        $(OutDir)\node_modules\union\test\fixtures\index.js;
                                                         $(OutDir)\node_modules\union\test\helpers\index.js;">
         <Authenticode>Microsoft400</Authenticode>
       </FilesToSign>

--- a/msbuild/ChromeDebugAdapter.csproj
+++ b/msbuild/ChromeDebugAdapter.csproj
@@ -24,7 +24,7 @@
 
   <Target Name="GetFilesToSign" DependsOnTargets="CopyFilesToSign" BeforeTargets="SignFiles">
     <ItemGroup>
-      <FilesToSign Include="$(OutDir)\**\*.js" />
+      <FilesToSign Include="$(OutDir)\**\*.js">
       <!--<FilesToSign Include="$(OutDir)\**\*.js" Exclude="$(OutDir)\node_modules\globule\test\fixtures\expand\js\foo.js;
                                                         $(OutDir)\node_modules\globule\test\fixtures\expand\js\bar.js;
                                                         $(OutDir)\node_modules\resolve\test\resolver\other_path\root.js;
@@ -34,7 +34,7 @@
                                                         $(OutDir)\node_modules\vsce\node_modules\tmp\test\symlinkme\file.js;
                                                         $(OutDir)\node_modules\resolve\test\resolver\mug.js;
                                                         $(OutDir)\node_modules\resolve\test\resolver\other_path\lib\other-lib.js;
-                                                        $(OutDir)\node_modules\union\test\fixtures\index.js;" /> -->
+                                                        $(OutDir)\node_modules\union\test\fixtures\index.js;"> -->
         <Authenticode>Microsoft400</Authenticode>
       </FilesToSign>
     </ItemGroup>

--- a/msbuild/ChromeDebugAdapter.csproj
+++ b/msbuild/ChromeDebugAdapter.csproj
@@ -29,7 +29,7 @@
                                                         $(OutDir)\node_modules\resolve\test\resolver\mug.js;
                                                         $(OutDir)\node_modules\resolve\test\pathfilter\deep_ref\main.js;
                                                         $(OutDir)\node_modules\resolve\test\resolver\baz\doom.js;
-                                                        $(OutDir)\node_modules\node_modules\vsce\node_modules\tmp\test\symlinkme\file.js;
+                                                        $(OutDir)\node_modules\vsce\node_modules\tmp\test\symlinkme\file.js;
                                                         $(OutDir)\node_modules\resolve\test\resolver\other_path\lib\other-lib.js;
                                                         $(OutDir)\node_modules\resolve\test\resolver\other_path\root.js;
                                                         $(OutDir)\node_modules\union\test\fixtures\index.js;

--- a/msbuild/ChromeDebugAdapter.sln
+++ b/msbuild/ChromeDebugAdapter.sln
@@ -1,0 +1,25 @@
+﻿
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio 15
+VisualStudioVersion = 15.0.27422.0
+MinimumVisualStudioVersion = 10.0.40219.1
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "ChromeDebugAdapter", "ChromeDebugAdapter.csproj", "{FF72AE19-1081-4A1D-A2EA-EA50A3530289}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Any CPU = Debug|Any CPU
+		Release|Any CPU = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{FF72AE19-1081-4A1D-A2EA-EA50A3530289}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{FF72AE19-1081-4A1D-A2EA-EA50A3530289}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{FF72AE19-1081-4A1D-A2EA-EA50A3530289}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{FF72AE19-1081-4A1D-A2EA-EA50A3530289}.Release|Any CPU.Build.0 = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(ExtensibilityGlobals) = postSolution
+		SolutionGuid = {A0031A13-F520-495A-A28F-38294166BF6F}
+	EndGlobalSection
+EndGlobal


### PR DESCRIPTION
These two files have no connection to anything else in the repo, and are only used to sign the JS files from this repo when the files get distributed as part of Visual Studio installations.