### PR TITLE
Respect locale passed on from Pinezorro

### DIFF
--- a/src/chromeDebugAdapter.ts
+++ b/src/chromeDebugAdapter.ts
@@ -16,7 +16,7 @@ import * as utils from './utils';
 import * as errors from './errors';
 
 import * as nls from 'vscode-nls';
-const localize = nls.config(process.env.VSCODE_NLS_CONFIG)();
+let localize = nls.config(process.env.VSCODE_NLS_CONFIG)();
 
 // Keep in sync with sourceMapPathOverrides package.json default
 const DefaultWebSourceMapPathOverrides: ISourceMapPathOverrides = {
@@ -40,6 +40,10 @@ export class ChromeDebugAdapter extends CoreDebugAdapter {
         const capabilities: VSDebugProtocolCapabilities = super.initialize(args);
         capabilities.supportsRestartRequest = true;
         capabilities.supportsSetExpression = true;
+
+        if (args.locale) {
+            localize = nls.config({ locale: args.locale })();
+        }
 
         return capabilities;
     }


### PR DESCRIPTION
We do this for chrome-core but that doesn't work for the strings generated in this repo.