### PR TITLE
Launch Chrome in unelevated state on Windows platform by using `wmic call create`.

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -38,7 +38,8 @@ const watchedSources = [
 ];
 
 const scripts = [
-    'src/terminateProcess.sh'
+    'src/terminateProcess.sh',
+    'src/launchUnelevated.js'
 ];
 
 const lintSources = [

--- a/src/chromeDebugInterfaces.d.ts
+++ b/src/chromeDebugInterfaces.d.ts
@@ -23,6 +23,7 @@ export interface ILaunchRequestArgs extends Core.ILaunchRequestArgs, ICommonRequ
     userDataDir?: string;
     breakOnLoad?: boolean;
     _clientOverlayPausedMessage?: string;
+    shouldLaunchChromeUnelevated?: boolean;
 }
 
 export interface IAttachRequestArgs extends Core.IAttachRequestArgs, ICommonRequestArgs {

--- a/src/launchUnelevated.js
+++ b/src/launchUnelevated.js
@@ -1,0 +1,28 @@
+var objShell = new ActiveXObject("shell.application");
+var objShellWindows = objShell.Windows();
+if (objShellWindows != null)
+{
+    var fso = new ActiveXObject("Scripting.FileSystemObject");
+    var tempFile = WScript.Arguments(0);
+    var file = fso.OpenTextFile(tempFile, 2, true, 0);
+    file.WriteLine("");
+    file.Close();
+
+    // Build up the parameters for launching the application and getting the process id
+    var command = "cmd";
+    var params = "/c \"wmic /OUTPUT:" + tempFile + " process call create \"";
+    for (var i = 1; i < WScript.Arguments.length; i++) {
+        params += WScript.Arguments(i) + " ";
+    }
+    params += "\"\"";
+
+    for (var i = 0; i < objShellWindows.count; i++)
+    {
+        var item = objShellWindows.Item(i);
+        if (item)
+        {
+            item.Document.Application.ShellExecute(command, params);
+            break;
+        }
+    }
+}


### PR DESCRIPTION
This change is needed because when VS is started in elevated mode, DA will be started in elevated mode too. Any processes launched by DA, in our case Chrome, will be started in elevated mode as well. Chrome is known to have issues with elevated mode. 

When DA received `shouldLaunchChromeUnelevated` launch parameter, it will call `cscript.exe` to run a customized Windows Script Host program (`launchUnelevated.js`) to launch chrome process in unelevated mode. 

`launchUnelevated.js` will dump the process id information to a temporary file negotiated with DA, so after the WSH process is finished, DA will poll the content of the file and find out the PID of the launched Chrome process.