### PR TITLE
Add an event with the target's version information

### DIFF
--- a/src/chromeDebugAdapter.ts
+++ b/src/chromeDebugAdapter.ts
@@ -202,6 +202,9 @@ export class ChromeDebugAdapter extends CoreDebugAdapter {
                 return properties
             });
 
+            // Send the versions information as it's own event so we can easily backfill other events in the user session if needed
+            versionInformationPromise.then(versionInformation => telemetry.telemetry.reportEvent('target-version', versionInformation));
+
             // Add version information to all telemetry events from now on
             telemetry.telemetry.addCustomGlobalProperty(versionInformationPromise);
         });


### PR DESCRIPTION
* The event will let us backfill the version information to other events if necessary
* Initially we'll use this event to back-fill the version information to the clientRequest/launch event, which will probably not have it given the workaround we apply for VS to make the telemetry sync for the time being