### PR TITLE
Changes the way we handle process id semaphore file.

### DIFF
--- a/src/utils.ts
+++ b/src/utils.ts
@@ -3,6 +3,8 @@
  *--------------------------------------------------------*/
 
 import * as path from 'path';
+import * as crypto from 'crypto';
+
 import {utils as coreUtils, chromeConnection } from 'vscode-chrome-debug-core';
 
 const WIN_APPDATA = process.env.LOCALAPPDATA || '/';
@@ -66,3 +68,7 @@ export class DebounceHelper {
 
 export const targetFilter: chromeConnection.ITargetFilter =
     target => target && (!target.type || target.type === 'page');
+
+export function generateRandomString(length: number): string {
+    return crypto.randomBytes(length).toString('hex');;
+}


### PR DESCRIPTION
Now we always create a file with randomized file name and delete it after we have read the content of it.

We want to address a risk that when multiple debug adapters are launched by VS simultaneously, each process might overwrite the content of the same file.