### PR TITLE
Added a new package command with a packagePath option

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -141,7 +141,10 @@ gulp.task('vsce-publish', function () {
     return vsce.publish();
 });
 gulp.task('vsce-package', function () {
-    return vsce.createVSIX();
+    const usePackagePathOptionIndex = process.argv.findIndex(arg => arg === "--packagePath");
+    const packagePath = process.argv[usePackagePathOptionIndex + 1];
+    const options = packagePath !== undefined ? { packagePath: packagePath } : {};
+    return vsce.createVSIX(options);
 });
 
 gulp.task('publish', function (callback) {

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -142,7 +142,7 @@ gulp.task('vsce-publish', function () {
 });
 gulp.task('vsce-package', function () {
     const usePackagePathOptionIndex = process.argv.findIndex(arg => arg === "--packagePath");
-    const packagePath = process.argv[usePackagePathOptionIndex + 1];
+    const packagePath = usePackagePathOptionIndex >= 0 ? process.argv[usePackagePathOptionIndex + 1] : undefined;
     const options = packagePath !== undefined ? { packagePath: packagePath } : {};
     return vsce.createVSIX(options);
 });

--- a/package.json
+++ b/package.json
@@ -75,7 +75,8 @@
     "postinstall": "node ./node_modules/vscode/bin/install",
     "patch": "npm version patch -m '%s'",
     "minor": "npm version minor -m '%s'",
-    "major": "npm version major -m '%s'"
+    "major": "npm version major -m '%s'",
+    "package": "gulp package"
   },
   "contributes": {
     "breakpoints": [


### PR DESCRIPTION
We'll use this command in our build system. Generating a .vsix with the same name always makes it easier to configure the build system. We'll use "npm run package -- --packagePath chrome-debug2.vsix"

(Please tell me which version of the code you think is better, this one or the node one, and I'll make both of them match that version)