### PR TITLE
Fix for 'Cannot acquire Chrome process id' error in VS 15.7

### DIFF
--- a/src/launchUnelevated.js
+++ b/src/launchUnelevated.js
@@ -28,7 +28,7 @@ if (objShellWindows != null)
 
     if (objShellWindows.count === 0) {
         // If no File Explorer windows are open fall-back to this alternative way of executing the command
-        var item = objShellWindows.FindWindowSW(0, 0, /*SWC_DESKTOP*/8, 0, /*SWFO_NEEDDISPATCH*/1);
+        var item = objShellWindows.FindWindowSW(/*NULL*/0, /*NULL*/0, /*SWC_DESKTOP*/8, /*NULL*/0, /*SWFO_NEEDDISPATCH*/1);
         item.Document.Application.ShellExecute(command, params);
     }
 }

--- a/src/launchUnelevated.js
+++ b/src/launchUnelevated.js
@@ -28,7 +28,8 @@ if (objShellWindows != null)
 
     if (objShellWindows.count === 0) {
         // If no File Explorer windows are open fall-back to this alternative way of executing the command
-        var item = objShellWindows.FindWindowSW(/*NULL*/0, /*NULL*/0, /*SWC_DESKTOP*/8, /*NULL*/0, /*SWFO_NEEDDISPATCH*/1);
+        // See IShellWindows::FindWindowSW at https://msdn.microsoft.com/en-us/library/windows/desktop/cc836568(v=vs.85).aspx
+        var item = objShellWindows.FindWindowSW(/*pvarLoc=NULL*/0, /*pvarLocRoot=NULL*/0, /*SWC_DESKTOP*/8, /*phwnd=NULL*/0, /*SWFO_NEEDDISPATCH*/1);
         item.Document.Application.ShellExecute(command, params);
     }
 }

--- a/src/launchUnelevated.js
+++ b/src/launchUnelevated.js
@@ -10,7 +10,7 @@ if (objShellWindows != null)
 
     // Build up the parameters for launching the application and getting the process id
     var command = "cmd";
-    var params = "/c \"wmic /OUTPUT:" + tempFile + " process call create \"";
+    var params = "/c \"wmic /OUTPUT:\"" + tempFile + "\" process call create \"";
     for (var i = 1; i < WScript.Arguments.length; i++) {
         params += WScript.Arguments(i) + " ";
     }
@@ -24,5 +24,11 @@ if (objShellWindows != null)
             item.Document.Application.ShellExecute(command, params);
             break;
         }
+    }
+
+    if (objShellWindows.count === 0) {
+        // If no File Explorer windows are open fall-back to this alternative way of executing the command
+        var item = objShellWindows.FindWindowSW(0, 0, /*SWC_DESKTOP*/8, 0, /*SWFO_NEEDDISPATCH*/1);
+        item.Document.Application.ShellExecute(command, params);
     }
 }


### PR DESCRIPTION
Line 13 fix is because some users have a - in their username, and the tempFile ended up being C:\Users\some-username\ and wmic failed with invalid path without the quotes

Line 29 fallback is because objShellWindows.count on line 19 is the number of File Explorer windows currently open. If the user doesn't have any File Explorer windows currently open that number is 0, and that logic fails.

In the future we'll remove the objShellWindows.count logic altogether and use the new objShellWindows.FindWindowSW instead.  To try to minimize the chances of breaking anything for this fix we are going to leave the existing way as the default and fall-back to the new way if the old way fails.