### PR TITLE
Set chrome PID in all launch cases

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1722,7 +1722,7 @@
           "integrity": "sha512-Dnfc9ROAPrkkeLIUweEbh7LFT9Mc53tO/bbM044rKjhgAEyIGKvKXg97PM/kRizZIfUHaROZIoeEaWao+Unzfw==",
           "dev": true,
           "requires": {
-            "balanced-match": "^1.0.0",
+            "balanced-match": "1.0.0",
             "concat-map": "0.0.1"
           }
         },

--- a/src/chromeDebugAdapter.ts
+++ b/src/chromeDebugAdapter.ts
@@ -428,6 +428,9 @@ export class ChromeDebugAdapter extends CoreDebugAdapter {
             }
             const chromeProc = spawn(chromePath, chromeArgs, options);
             chromeProc.unref();
+
+            this._chromePID = chromeProc.pid;
+
             return chromeProc;
         }
     }


### PR DESCRIPTION
Fixes an issue where the chrome PID was not set in some situations. In Visual Studio, without setting the PID, the chrome process will not terminate properly.