### PR TITLE
Simplify targetFilter

### DIFF
--- a/src/utils.ts
+++ b/src/utils.ts
@@ -65,4 +65,4 @@ export class DebounceHelper {
 }
 
 export const targetFilter: chromeConnection.ITargetFilter =
-    target => target && (!target.type || target.type === 'page');
+    target => target && !!target.webSocketDebuggerUrl;

--- a/test/utils.test.ts
+++ b/test/utils.test.ts
@@ -79,4 +79,24 @@ suite('Utils', () => {
                 '/usr/bin/google-chrome');
         });
     });
+
+    suite('targetFilter()', () => {
+        test('filter irregular targets', () => {
+            const Utils = getUtils();
+            const targets = [
+                {
+                    // Kept (webSocketDebuggerUrl is provided and truthy)
+                    id: 'keep',
+                    webSocketDebuggerUrl: 'ws://...'
+                },
+                {
+                    // Discarded (webSocketDebuggerUrl is not provided or falsy)
+                    id: 'discard',
+                }
+            ];
+            assert.deepEqual(
+                targets.filter(Utils.targetFilter),
+                [{id: 'keep', webSocketDebuggerUrl: 'ws://...'}]);
+        });
+    });
 });


### PR DESCRIPTION
For background, see conversation beneath #623, which was merged and then reverted via 7c1865ba.

Although a more robust configuration-based option whitelisting target types is a valid approach, I did note that:
 - Since we already pass falsy "type" through the filter, we aren't being very strict about this field to begin with.
 - Imitating the `chrome://inspect/#devices` tab feels most correct—if there is a `webSocketDebuggerUrl` available, then we can attach, and if there isn't, then we can't. This has the added benefit of not showing targets that already have a debugger attached (an improvement over `chrome://inspect/#devices` IMO, which provides a link to "inspect" which doesn't work if there is already a debugger attached).

(I encountered this problem trying to debug Electron `<webview>`s, which have `"type": "webview"` in the debugger manifest, but #623 has some other good examples.)