### PR TITLE
Workaround for json/version failing

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6195,9 +6195,9 @@
       }
     },
     "vscode-chrome-debug-core": {
-      "version": "6.7.14",
-      "resolved": "https://registry.npmjs.org/vscode-chrome-debug-core/-/vscode-chrome-debug-core-6.7.14.tgz",
-      "integrity": "sha512-izE6nPfxQONqdTR6cihORLzX9f/kdfNHebDL46qHVdxzb++BpU4BGaj7lAit/hQoYwKMsJgd6z/VskEdMic4oA==",
+      "version": "6.7.15",
+      "resolved": "https://registry.npmjs.org/vscode-chrome-debug-core/-/vscode-chrome-debug-core-6.7.15.tgz",
+      "integrity": "sha512-pXp81DJH0AdTv0/hwjYB6QgJu4uMXmCMnvfl4shN7RX4Mv1ZaAmMyGVvZhZ9kvlHWlksYw0n+93VGIijLbJunw==",
       "requires": {
         "@types/source-map": "^0.1.27",
         "devtools-protocol": "0.0.588169",

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
   ],
   "license": "SEE LICENSE IN LICENSE.txt",
   "dependencies": {
-    "vscode-chrome-debug-core": "^6.7.14",
+    "vscode-chrome-debug-core": "^6.7.15",
     "vscode-debugadapter": "^1.31.0",
     "vscode-nls": "^4.0.0"
   },

--- a/src/chromeDebugAdapter.ts
+++ b/src/chromeDebugAdapter.ts
@@ -17,7 +17,6 @@ import * as errors from './errors';
 
 import * as nls from 'vscode-nls';
 import { FinishedStartingUpEventArguments } from 'vscode-chrome-debug-core/lib/src/executionTimingsReporter';
-import { version } from 'vscode';
 let localize = nls.loadMessageBundle();
 
 // Keep in sync with sourceMapPathOverrides package.json default
@@ -289,8 +288,8 @@ export class ChromeDebugAdapter extends CoreDebugAdapter {
                         logger.log(`/json/version failed, attempting workaround to get the version`);
                         // If the original way failed, we try to use versionInformationPromise to get this information
                         const versionInformation = await versionInformationPromise;
-                        const browserVersion = Version.parse(versionInformation['Versions.Target.Version']);
-                        this._breakOnLoadHelper.setBrowserVersion(browserVersion);
+                        const alternativeBrowserVersion = Version.parse(versionInformation['Versions.Target.Version']);
+                        this._breakOnLoadHelper.setBrowserVersion(alternativeBrowserVersion);
                     }
                 }
             } catch (exception) {

--- a/src/chromeDebugAdapter.ts
+++ b/src/chromeDebugAdapter.ts
@@ -282,9 +282,7 @@ export class ChromeDebugAdapter extends CoreDebugAdapter {
                 if (this._breakOnLoadHelper) {
                     // This is what -core is doing. We only actually care to see if this fails, to see if we need to apply the workaround
                     const browserVersion = (await this._chromeConnection.version).browser;
-                    if (browserVersion.isAtLeastVersion(0, 1)) { // If this is false it means it's unknown version
-                        this._breakOnLoadHelper.setBrowserVersion(browserVersion);
-                    } else {
+                    if (!browserVersion.isAtLeastVersion(0, 1)) { // If this is true it means it's unknown version
                         logger.log(`/json/version failed, attempting workaround to get the version`);
                         // If the original way failed, we try to use versionInformationPromise to get this information
                         const versionInformation = await versionInformationPromise;


### PR DESCRIPTION
We've seen some cases where json/version fails and we can't get the version. That makes the break-on-load feature not work on the first line on the file on Chrome 69.

We use this workaround to try to use the CDTP Browser.GetVersion API only if the first mechanism fails.

This change depends on this PR: https://github.com/Microsoft/vscode-chrome-debug-core/pull/354