### PR TITLE
Fixtures model

### DIFF
--- a/test/int/core-v2/chrome/collections/async.ts
+++ b/test/int/core-v2/chrome/collections/async.ts
@@ -1,0 +1,8 @@
+/*---------------------------------------------------------
+ * Copyright (C) Microsoft Corporation. All rights reserved.
+ *--------------------------------------------------------*/
+
+export function asyncMap<T, U>(array: ReadonlyArray<T>,
+    callbackfn: (value: T, index: number, array: ReadonlyArray<T>) => Promise<U> | U, thisArg?: any): Promise<U[]> {
+    return Promise.all(array.map(callbackfn, thisArg));
+}

--- a/test/int/fixtures/defaultFixture.ts
+++ b/test/int/fixtures/defaultFixture.ts
@@ -5,7 +5,7 @@
 import { IFixture } from './fixture';
 import { ExtendedDebugClient } from 'vscode-chrome-debug-core-testsupport';
 import * as testSetup from '../testSetup';
-import { IBeforeAndAfterContext } from 'mocha';
+import { IBeforeAndAfterContext, ITestCallbackContext } from 'mocha';
 
 /**
  * Default set up for all our tests. We expect all our tests to need to do this setup
@@ -13,12 +13,12 @@ import { IBeforeAndAfterContext } from 'mocha';
  */
 export class DefaultFixture implements IFixture {
     private constructor(public readonly debugClient: ExtendedDebugClient) {
-        // Running tests on CI can time out at the default 5s, so we up this to 10s
+        // Running tests on CI can time out at the default 5s, so we up this to 15s
         debugClient.defaultTimeout = 15000;
     }
 
     /** Create a new fixture using the provided setup context */
-    public static async create(context: IBeforeAndAfterContext): Promise<DefaultFixture> {
+    public static async create(context: IBeforeAndAfterContext | ITestCallbackContext): Promise<DefaultFixture> {
         return new DefaultFixture(await testSetup.setup(context));
     }
 

--- a/test/int/fixtures/defaultFixture.ts
+++ b/test/int/fixtures/defaultFixture.ts
@@ -1,0 +1,37 @@
+/*---------------------------------------------------------
+ * Copyright (C) Microsoft Corporation. All rights reserved.
+ *--------------------------------------------------------*/
+
+import { IFixture } from './fixture';
+import { ExtendedDebugClient } from 'vscode-chrome-debug-core-testsupport';
+import * as testSetup from '../testSetup';
+import { IBeforeAndAfterContext } from 'mocha';
+
+/**
+ * Default set up for all our tests. We expect all our tests to need to do this setup
+ * which includes configure the debug adapter, logging, etc...
+ */
+export class DefaultFixture implements IFixture {
+    private constructor(public readonly debugClient: ExtendedDebugClient) {
+        // Running tests on CI can time out at the default 5s, so we up this to 10s
+        debugClient.defaultTimeout = 15000;
+    }
+
+    /** Create a new fixture using the provided setup context */
+    public static async create(context: IBeforeAndAfterContext): Promise<DefaultFixture> {
+        return new DefaultFixture(await testSetup.setup(context));
+    }
+
+    /** Create a new fixture using the full title of the test case currently running */
+    public static async createWithTitle(testTitle: string): Promise<DefaultFixture> {
+        return new DefaultFixture(await testSetup.setupWithTitle(testTitle));
+    }
+
+    public async cleanUp(): Promise<void> {
+        await testSetup.teardown();
+    }
+
+    public toString(): string {
+        return `DefaultFixture`;
+    }
+}

--- a/test/int/fixtures/fixture.ts
+++ b/test/int/fixtures/fixture.ts
@@ -1,0 +1,27 @@
+/*---------------------------------------------------------
+ * Copyright (C) Microsoft Corporation. All rights reserved.
+ *--------------------------------------------------------*/
+
+import { PromiseOrNot } from 'vscode-chrome-debug-core';
+
+/**
+ * See https://en.wikipedia.org/wiki/Test_fixture for more context
+ */
+
+/**
+ * A fixture represents a particular piece of set up of the context, or the environment or
+ * the configuration needed for a test or suite to run.
+ * The fixture should make those changes during it's constructor or static constructor method,
+ * and it'll "clean up" those changes with the cleanUp method
+ */
+export interface IFixture {
+    /** Clean-up the context, or changes made by the fixture */
+    cleanUp(): PromiseOrNot<void>;
+}
+
+/**
+ * A fixture representing that no setup is needed
+ */
+export class NullFixture implements IFixture {
+    public cleanUp(): void { }
+}

--- a/test/int/fixtures/launchProject.ts
+++ b/test/int/fixtures/launchProject.ts
@@ -1,0 +1,51 @@
+/*---------------------------------------------------------
+ * Copyright (C) Microsoft Corporation. All rights reserved.
+ *--------------------------------------------------------*/
+
+import { TestProjectSpec } from '../framework/frameworkTestSupport';
+import { IFixture } from './fixture';
+import { DefaultFixture } from './defaultFixture';
+import { LaunchWebServer } from './launchWebServer';
+import { LaunchPuppeteer } from '../puppeteer/launchPuppeteer';
+import { ExtendedDebugClient } from 'vscode-chrome-debug-core-testsupport';
+import { Page, Browser } from 'puppeteer';
+
+/** Perform all the steps neccesary to launch a particular project such as:
+ *    - Default fixture/setup
+ *    - Launch web-server
+ *    - Connect puppeteer to Chrome
+ */
+export class LaunchProject implements IFixture {
+    private constructor(
+        private readonly _defaultFixture: DefaultFixture,
+        private readonly _launchWebServer: LaunchWebServer,
+        private readonly _launchPuppeteer: LaunchPuppeteer) { }
+
+    public static async create(testTitle: string, testSpec: TestProjectSpec): Promise<LaunchProject> {
+        const defaultFixture = await DefaultFixture.createWithTitle(testTitle);
+        const launchWebServer = new LaunchWebServer(testSpec);
+        const launchPuppeteer = await LaunchPuppeteer.create(defaultFixture.debugClient, testSpec);
+        return new LaunchProject(defaultFixture, launchWebServer, launchPuppeteer);
+    }
+
+    /** Client for the debug adapter being used for this test */
+    public get debugClient(): ExtendedDebugClient {
+        return this._defaultFixture.debugClient;
+    }
+
+    /** Object to control the debugged browser via puppeteer */
+    public get browser(): Browser {
+        return this._launchPuppeteer.browser;
+    }
+
+    /** Object to control the debugged page via puppeteer */
+    public get page(): Page {
+        return this._launchPuppeteer.page;
+    }
+
+    public async cleanUp(): Promise<void> {
+        await this._launchPuppeteer.cleanUp();
+        await this._launchWebServer.cleanUp();
+        await this._defaultFixture.cleanUp();
+    }
+}

--- a/test/int/fixtures/launchProject.ts
+++ b/test/int/fixtures/launchProject.ts
@@ -9,6 +9,7 @@ import { LaunchWebServer } from './launchWebServer';
 import { LaunchPuppeteer } from '../puppeteer/launchPuppeteer';
 import { ExtendedDebugClient } from 'vscode-chrome-debug-core-testsupport';
 import { Page, Browser } from 'puppeteer';
+import { ITestCallbackContext, IBeforeAndAfterContext } from 'mocha';
 
 /** Perform all the steps neccesary to launch a particular project such as:
  *    - Default fixture/setup
@@ -21,8 +22,8 @@ export class LaunchProject implements IFixture {
         private readonly _launchWebServer: LaunchWebServer,
         private readonly _launchPuppeteer: LaunchPuppeteer) { }
 
-    public static async create(testTitle: string, testSpec: TestProjectSpec): Promise<LaunchProject> {
-        const defaultFixture = await DefaultFixture.createWithTitle(testTitle);
+    public static async create(testContext: IBeforeAndAfterContext | ITestCallbackContext, testSpec: TestProjectSpec): Promise<LaunchProject> {
+        const defaultFixture = await DefaultFixture.create(testContext);
         const launchWebServer = new LaunchWebServer(testSpec);
         const launchPuppeteer = await LaunchPuppeteer.create(defaultFixture.debugClient, testSpec);
         return new LaunchProject(defaultFixture, launchWebServer, launchPuppeteer);

--- a/test/int/fixtures/launchWebServer.ts
+++ b/test/int/fixtures/launchWebServer.ts
@@ -1,0 +1,28 @@
+/*---------------------------------------------------------
+ * Copyright (C) Microsoft Corporation. All rights reserved.
+ *--------------------------------------------------------*/
+
+import { createServer } from 'http-server';
+import { IFixture } from './fixture';
+import { TestProjectSpec } from '../framework/frameworkTestSupport';
+import { HttpOrHttpsServer } from '../types/server';
+
+/**
+ * Launch a web-server for the test project listening on the default port
+ */
+export class LaunchWebServer implements IFixture {
+    private readonly server: HttpOrHttpsServer;
+
+    public constructor(testSpec: TestProjectSpec) {
+        this.server = createServer({ root: testSpec.props.webRoot });
+        this.server.listen(7890);
+    }
+
+    public async cleanUp(): Promise<void> {
+        this.server.close(err => console.log('Error closing server in teardown: ' + (err && err.message)));
+    }
+
+    public toString(): string {
+        return `LaunchWebServer`;
+    }
+}

--- a/test/int/fixtures/launchWebServer.ts
+++ b/test/int/fixtures/launchWebServer.ts
@@ -15,6 +15,7 @@ export class LaunchWebServer implements IFixture {
 
     public constructor(testSpec: TestProjectSpec) {
         this.server = createServer({ root: testSpec.props.webRoot });
+        // TODO: This should probably be extracted somehow and randomized at some point (Also replace 7890 in the url)
         this.server.listen(7890);
     }
 

--- a/test/int/fixtures/multipleFixtures.ts
+++ b/test/int/fixtures/multipleFixtures.ts
@@ -1,0 +1,19 @@
+/*---------------------------------------------------------
+ * Copyright (C) Microsoft Corporation. All rights reserved.
+ *--------------------------------------------------------*/
+
+import { IFixture } from './fixture';
+import { asyncMap } from '../core-v2/chrome/collections/async';
+
+/** Combine multiple fixtures into a single fixture, for easier management (e.g. you just need to call a single cleanUp method) */
+export class MultipleFixtures implements IFixture {
+    private readonly _fixtures: IFixture[];
+
+    public constructor(...fixtures: IFixture[]) {
+        this._fixtures = fixtures;
+    }
+
+    public async cleanUp(): Promise<void> {
+        await asyncMap(this._fixtures, fixture => fixture.cleanUp());
+    }
+}

--- a/test/int/fixtures/testUsing.ts
+++ b/test/int/fixtures/testUsing.ts
@@ -1,0 +1,23 @@
+/*---------------------------------------------------------
+ * Copyright (C) Microsoft Corporation. All rights reserved.
+ *--------------------------------------------------------*/
+
+import { IFixture } from './fixture';
+import { PromiseOrNot } from 'vscode-chrome-debug-core';
+
+/** Run a test doing the setup/cleanup indicated by the provided fixtures */
+async function testUsingFunction<T extends IFixture>(
+    expectation: string,
+    fixtureProvider: () => PromiseOrNot<T>,
+    testFunction: (fixtures: T) => Promise<void>) {
+    return test(expectation, async function () {
+        const fixture = await fixtureProvider();
+        try {
+            await testFunction(fixture);
+        } finally {
+            await fixture.cleanUp();
+        }
+    });
+}
+
+export const testUsing = testUsingFunction;

--- a/test/int/fixtures/testUsing.ts
+++ b/test/int/fixtures/testUsing.ts
@@ -4,14 +4,15 @@
 
 import { IFixture } from './fixture';
 import { PromiseOrNot } from 'vscode-chrome-debug-core';
+import { ITestCallbackContext } from 'mocha';
 
 /** Run a test doing the setup/cleanup indicated by the provided fixtures */
 async function testUsingFunction<T extends IFixture>(
     expectation: string,
-    fixtureProvider: () => PromiseOrNot<T>,
+    fixtureProvider: (context: ITestCallbackContext) => PromiseOrNot<T>,
     testFunction: (fixtures: T) => Promise<void>) {
     return test(expectation, async function () {
-        const fixture = await fixtureProvider();
+        const fixture = await fixtureProvider(this);
         try {
             await testFunction(fixture);
         } finally {

--- a/test/int/framework/framework.react.test.ts
+++ b/test/int/framework/framework.react.test.ts
@@ -11,12 +11,15 @@ import * as path from 'path';
 import * as testSetup from '../testSetup';
 import { setBreakpoint, setConditionalBreakpoint } from '../intTestSupport';
 import { puppeteerSuite, puppeteerTest } from '../puppeteer/puppeteerSuite';
-import { FrameworkTestSuite } from './frameworkCommonTests';
+import { FrameworkTestSuite, testBreakOnLoad } from './frameworkCommonTests';
 import { TestProjectSpec } from './frameworkTestSupport';
 
 const DATA_ROOT = testSetup.DATA_ROOT;
 const REACT_PROJECT_ROOT = path.join(DATA_ROOT, 'react', 'dist');
 const TEST_SPEC = new TestProjectSpec( { projectRoot: REACT_PROJECT_ROOT } );
+
+// This test doesn't use puppeteer, so we leave it outside the suite
+testBreakOnLoad('React', TEST_SPEC, 'react_App_render');
 
 puppeteerSuite('React Framework Tests', TEST_SPEC, (suiteContext) => {
 
@@ -24,7 +27,6 @@ puppeteerSuite('React Framework Tests', TEST_SPEC, (suiteContext) => {
         const frameworkTests = new FrameworkTestSuite('React', suiteContext);
         frameworkTests.testPageReloadBreakpoint('react_App_render');
         frameworkTests.testPauseExecution();
-        frameworkTests.testBreakOnLoad('react_App_render');
         frameworkTests.testStepOver('react_Counter_increment');
         frameworkTests.testStepOut('react_Counter_increment', 'react_Counter_stepOut');
         frameworkTests.testStepIn('react_Counter_stepInStop', 'react_Counter_stepIn');

--- a/test/int/framework/frameworkTestSupport.ts
+++ b/test/int/framework/frameworkTestSupport.ts
@@ -10,6 +10,7 @@ import { BreakpointLocation } from '../intTestSupport';
 import { ILaunchRequestArgs } from '../../../src/chromeDebugInterfaces';
 import { MakePropertyRequired } from '../core-v2/typeUtils';
 import { IValidatedMap } from '../core-v2/chrome/collections/validatedMap';
+import { DATA_ROOT } from '../testSetup';
 
 /*
  * A collection of supporting classes/functions for running framework tests
@@ -37,7 +38,6 @@ export interface ProjectSpecProps {
  * attached to in order to test the debug adapter)
  */
 export class TestProjectSpec {
-
     _props: MakePropertyRequired<ProjectSpecProps, keyof ProjectSpecProps>;
     get props() { return this._props; }
 
@@ -64,6 +64,19 @@ export class TestProjectSpec {
                 webRoot: webRoot
             }
         };
+    }
+
+    /**
+     * Specify project by it's location relative to the testdata folder e.g.:
+     *    - TestProjectSpec.fromTestPath('react_with_loop/dist')
+     *    - TestProjectSpec.fromTestPath('simple')
+     *
+     * The path *can only* use forward-slahes "/" as separators
+     */
+    public static fromTestPath(reversedSlashesRelativePath: string): TestProjectSpec {
+        const pathComponents = reversedSlashesRelativePath.split('/');
+        const projectAbsolutePath = path.join(...[DATA_ROOT].concat(pathComponents));
+        return new TestProjectSpec({ projectRoot: projectAbsolutePath });
     }
 
     /**

--- a/test/int/puppeteer/launchPuppeteer.ts
+++ b/test/int/puppeteer/launchPuppeteer.ts
@@ -1,0 +1,47 @@
+/*---------------------------------------------------------
+ * Copyright (C) Microsoft Corporation. All rights reserved.
+ *--------------------------------------------------------*/
+
+import { IFixture } from '../fixtures/fixture';
+import { launchTestAdapter } from '../intTestSupport';
+import { ExtendedDebugClient } from 'vscode-chrome-debug-core-testsupport';
+import { connectPuppeteer, getPageByUrl } from './puppeteerSupport';
+import { logCallsTo } from '../utils/logging';
+import { isThisV1 } from '../testSetup';
+import { TestProjectSpec } from '../framework/frameworkTestSupport';
+import { Browser, Page } from 'puppeteer';
+
+/**
+ * Launch the debug adapter using the Puppeteer version of chrome, and then connect to it
+ *
+ * The fixture offers access to both the browser, and page objects of puppeteer
+ */
+export class LaunchPuppeteer implements IFixture {
+    public constructor(public readonly browser: Browser, public readonly page: Page) { }
+
+    public static async create(debugClient: ExtendedDebugClient, testSpec: TestProjectSpec): Promise<LaunchPuppeteer> {
+        await launchTestAdapter(debugClient, testSpec.props.launchConfig);
+        const browser = await connectPuppeteer(9222);
+
+        const page = logCallsTo(await getPageByUrl(browser, testSpec.props.url), 'PuppeteerPage');
+
+        // This short wait appears to be necessary to completely avoid a race condition in V1 (tried several other
+        // strategies to wait deterministically for all scripts to be loaded and parsed, but have been unsuccessful so far)
+        // If we don't wait here, there's always a possibility that we can send the set breakpoint request
+        // for a subsequent test after the scripts have started being parsed/run by Chrome, yet before
+        // the target script is parsed, in which case the adapter will try to use breakOnLoad, but
+        // the instrumentation BP will never be hit, leaving our breakpoint in limbo
+        if (isThisV1) {
+            await new Promise(a => setTimeout(a, 500));
+        }
+
+        return new LaunchPuppeteer(browser, page);
+    }
+
+    public async cleanUp(): Promise<void> { }
+
+
+    public toString(): string {
+        return `LaunchPuppeteer`;
+    }
+}

--- a/test/int/puppeteer/puppeteerSuite.ts
+++ b/test/int/puppeteer/puppeteerSuite.ts
@@ -101,7 +101,7 @@ function puppeteerSuiteFunction(
 
     setup(async function () {
       const breakpointLabels = await loadProjectLabels(testSpec.props.webRoot);
-      const lauchProject = fixture = await LaunchProject.create(this.currentTest.title, testSpec);
+      const lauchProject = fixture = await LaunchProject.create(this, testSpec);
 
       testContext.reassignTo({
         testSpec, debugClient: lauchProject.debugClient, breakpointLabels, browser: lauchProject.browser, page: lauchProject.page

--- a/test/int/puppeteer/puppeteerSuite.ts
+++ b/test/int/puppeteer/puppeteerSuite.ts
@@ -3,31 +3,44 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import { createServer } from 'http-server';
 import * as puppeteer from 'puppeteer';
-import * as testSetup from '../testSetup';
-import { launchTestAdapter } from '../intTestSupport';
-import { getPageByUrl, connectPuppeteer } from './puppeteerSupport';
 import { FrameworkTestContext, TestProjectSpec, ReassignableFrameworkTestContext } from '../framework/frameworkTestSupport';
-import { isThisV1 } from '../testSetup';
-import { HttpOrHttpsServer } from '../types/server';
 import { loadProjectLabels } from '../labels';
-import { logCallsTo } from '../utils/logging';
 import { ISuiteCallbackContext, ISuite } from 'mocha';
+import { NullFixture } from '../fixtures/fixture';
+import { LaunchProject } from '../fixtures/launchProject';
 
 /**
  * Extends the normal debug adapter context to include context relevant to puppeteer tests.
  */
 export interface IPuppeteerTestContext extends FrameworkTestContext {
   /** The connected puppeteer browser object */
-  browser: puppeteer.Browser;
+  browser: puppeteer.Browser | null;
   /** The currently running html page in Chrome */
-  page: puppeteer.Page;
+  page: puppeteer.Page | null;
 }
 
 export class PuppeteerTestContext extends ReassignableFrameworkTestContext {
-  public constructor(public readonly browser: puppeteer.Browser, public readonly page: puppeteer.Page) {
+  private _browser: puppeteer.Browser | null = null;
+  private _page: puppeteer.Page | null = null;
+
+  public constructor() {
     super();
+  }
+
+  public get browser(): puppeteer.Browser | null {
+    return this._browser;
+  }
+
+  public get page(): puppeteer.Page | null {
+    return this._page;
+  }
+
+  public reassignTo(newWrapped: IPuppeteerTestContext): this {
+    super.reassignTo(newWrapped);
+    this._page = newWrapped.page;
+    this._browser = newWrapped.browser;
+    return this;
   }
 }
 
@@ -41,40 +54,24 @@ export class PuppeteerTestContext extends ReassignableFrameworkTestContext {
  */
 async function puppeteerTestFunction(
   description: string,
-  context: FrameworkTestContext,
+  context: PuppeteerTestContext,
   testFunction: (context: PuppeteerTestContext, page: puppeteer.Page) => Promise<any>,
   functionToDeclareTest: (description: string, callback: (this: ISuiteCallbackContext) => void) => ISuite = test
 ) {
   return functionToDeclareTest(description, async function () {
-    const debugClient = await context.debugClient;
-    await launchTestAdapter(debugClient, context.testSpec.props.launchConfig);
-    const browser = await connectPuppeteer(9222);
-
-    const page = logCallsTo(await getPageByUrl(browser, context.testSpec.props.url), 'PuppeteerPage');
-
-    // This short wait appears to be necessary to completely avoid a race condition in V1 (tried several other
-    // strategies to wait deterministically for all scripts to be loaded and parsed, but have been unsuccessful so far)
-    // If we don't wait here, there's always a possibility that we can send the set breakpoint request
-    // for a subsequent test after the scripts have started being parsed/run by Chrome, yet before
-    // the target script is parsed, in which case the adapter will try to use breakOnLoad, but
-    // the instrumentation BP will never be hit, leaving our breakpoint in limbo
-    if (isThisV1) {
-      await new Promise(a => setTimeout(a, 500));
-    }
-
-    await testFunction( new PuppeteerTestContext(browser, page).reassignTo(context), page);
+    await testFunction(context, context.page!);
   });
 }
 
 puppeteerTestFunction.skip = (
   description: string,
-  _context: FrameworkTestContext,
+  _context: PuppeteerTestContext,
   _testFunction: (context: IPuppeteerTestContext, page: puppeteer.Page) => Promise<any>
-) => test.skip(description, () => {throw new Error(`We don't expect this to be called`); });
+) => test.skip(description, () => { throw new Error(`We don't expect this to be called`); });
 
 puppeteerTestFunction.only = (
   description: string,
-  context: FrameworkTestContext,
+  context: PuppeteerTestContext,
   testFunction: (context: IPuppeteerTestContext, page: puppeteer.Page) => Promise<any>
 ) => puppeteerTestFunction(description, context, testFunction, test.only);
 
@@ -95,44 +92,34 @@ export const puppeteerTest = puppeteerTestFunction;
 function puppeteerSuiteFunction(
   description: string,
   testSpec: TestProjectSpec,
-  callback: (suiteContext: FrameworkTestContext) => any,
+  callback: (suiteContext: PuppeteerTestContext) => void,
   suiteFunctionToUse: (description: string, callback: (this: ISuiteCallbackContext) => void) => ISuite = suite
 ): Mocha.ISuite {
   return suiteFunctionToUse(description, () => {
-    const suiteContext = new ReassignableFrameworkTestContext();
-
-    let server: HttpOrHttpsServer | null;
+    let testContext = new PuppeteerTestContext();
+    let fixture: LaunchProject | NullFixture = new NullFixture(); // This variable is shared across all test of this suite
 
     setup(async function () {
-      let debugClient = await testSetup.setup(this);
-      suiteContext.reassignTo({
-        testSpec,
-        debugClient: debugClient,
-        breakpointLabels: await loadProjectLabels(testSpec.props.webRoot)
+      const breakpointLabels = await loadProjectLabels(testSpec.props.webRoot);
+      const lauchProject = fixture = await LaunchProject.create(this.currentTest.title, testSpec);
+
+      testContext.reassignTo({
+        testSpec, debugClient: lauchProject.debugClient, breakpointLabels, browser: lauchProject.browser, page: lauchProject.page
       });
-
-      // Running tests on CI can time out at the default 5s, so we up this to 10s
-      suiteContext.debugClient.defaultTimeout = 15000;
-
-      server = createServer({ root: testSpec.props.webRoot });
-      server.listen(7890);
     });
 
-    teardown(() => {
-      if (server) {
-        server.close(err => console.log('Error closing server in teardown: ' + (err && err.message)));
-        server = null;
-      }
-      return testSetup.teardown();
+    teardown(async () => {
+      fixture.cleanUp();
+      fixture = new NullFixture();
     });
 
-    callback(suiteContext);
+    callback(testContext);
   });
 }
 
 puppeteerSuiteFunction.only = (
   description: string,
   testSpec: TestProjectSpec,
-  callback: (suiteContext: FrameworkTestContext) => any,
+  callback: (suiteContext: PuppeteerTestContext) => any,
 ) => puppeteerSuiteFunction(description, testSpec, callback, suite.only);
 export const puppeteerSuite = puppeteerSuiteFunction;

--- a/test/int/testSetup.ts
+++ b/test/int/testSetup.ts
@@ -51,8 +51,17 @@ export const lowercaseDriveLetterDirname = __dirname.charAt(0).toLowerCase() + _
 export const PROJECT_ROOT = path.join(lowercaseDriveLetterDirname, '../../../');
 export const DATA_ROOT = path.join(PROJECT_ROOT, 'testdata/');
 
-export async function setup(context: IBeforeAndAfterContext, port?: number, launchProps?: ILaunchRequestArgs) {
-    const testTitle = context.currentTest.fullTitle();
+/** Default setup for all our tests, using the context of the setup method
+ *    - Best practise: The new best practise is to use the DefaultFixture when possible instead of calling this method directly
+ */
+export async function setup(context: IBeforeAndAfterContext, port?: number, launchProps?: ILaunchRequestArgs): Promise<ts.ExtendedDebugClient> {
+    return setupWithTitle(context.currentTest.fullTitle(), port, launchProps);
+}
+
+/** Default setup for all our tests, using the test title
+ *    - Best practise: The new best practise is to use the DefaultFixture when possible instead of calling this method directly
+ */
+export async function setupWithTitle(testTitle: string, port?: number, launchProps?: ILaunchRequestArgs): Promise<ts.ExtendedDebugClient> {
     setTestLogName(testTitle);
 
     if (!port) {
@@ -76,7 +85,7 @@ export async function setup(context: IBeforeAndAfterContext, port?: number, laun
 export async function teardown() {
     await ts.teardown();
 
-    if (process.platform === 'win32' && process.env.TF_BUILD) {
+    if (process.platform === 'win32') {
         // We only need to kill the chrome.exe instances on the Windows agent
         // TODO: Figure out a way to remove this
         killAllChrome();

--- a/test/int/testSetup.ts
+++ b/test/int/testSetup.ts
@@ -6,12 +6,13 @@
 import * as path from 'path';
 import * as tmp from 'tmp';
 import * as puppeteer from 'puppeteer';
-
+import * as _ from 'lodash';
 import * as ts from 'vscode-chrome-debug-core-testsupport';
+
 import { ILaunchRequestArgs } from '../../src/chromeDebugInterfaces';
 import { Dictionary } from 'lodash';
 import { logCallsTo, getDebugAdapterLogFilePath, setTestLogName } from './utils/logging';
-import { IBeforeAndAfterContext } from 'mocha';
+import { IBeforeAndAfterContext, ITestCallbackContext } from 'mocha';
 import { killAllChrome } from '../testUtils';
 
 const DEBUG_ADAPTER = './out/src/chromeDebug.js';
@@ -54,8 +55,9 @@ export const DATA_ROOT = path.join(PROJECT_ROOT, 'testdata/');
 /** Default setup for all our tests, using the context of the setup method
  *    - Best practise: The new best practise is to use the DefaultFixture when possible instead of calling this method directly
  */
-export async function setup(context: IBeforeAndAfterContext, port?: number, launchProps?: ILaunchRequestArgs): Promise<ts.ExtendedDebugClient> {
-    return setupWithTitle(context.currentTest.fullTitle(), port, launchProps);
+export async function setup(context: IBeforeAndAfterContext | ITestCallbackContext, port?: number, launchProps?: ILaunchRequestArgs): Promise<ts.ExtendedDebugClient> {
+    const currentTest = _.defaultTo(context.currentTest, context.test);
+    return setupWithTitle(currentTest.fullTitle(), port, launchProps);
 }
 
 /** Default setup for all our tests, using the test title


### PR DESCRIPTION
For the variables scope tests (I haven't sent that PR yet), we needed to change the testSpec that we use in each individual test, to use a different project in each test. I created the fixtures model to accomplish that.
The variables scopes test use the following code for their configuration:

`testUsing('globals', () => LaunchProject.create('Variables scopes globals', TestProjectSpec.fromTestPath('variablesScopes/globalScope')
`

- Where did we got the name fixture from? See https://en.wikipedia.org/wiki/Test_fixture

- DefaultFixture: Fixture for testSetup.setup
- LaunchWebServer: Launch web-serfer for the test project
- LaunchPuppeteer: Launch debug adapter and attach puppeteer to it
- LaunchProject: DefaultFixture + LaunchWebServer + LaunchPuppeteer
- MultipleFixtures: Combine multiple fixtures into one (Composite pattern)
- testUsingFunction: Run a test using a particular fixture
