### PR TITLE
Exclude inversify empty interfaces file from signing

### DIFF
--- a/msbuild/ChromeDebugAdapter.csproj
+++ b/msbuild/ChromeDebugAdapter.csproj
@@ -21,7 +21,7 @@
 
   <Target Name="GetFilesToSign" DependsOnTargets="DeleteUnwantedFiles" BeforeTargets="SignFiles">
     <ItemGroup>
-      <FilesToSign Include="$(OutDir)ziproot\**\*.js">
+      <FilesToSign Include="$(OutDir)ziproot\**\*.js" Exclude="$(OutDir)ziproot\**\inversify\es\interfaces\interfaces.js">
         <Authenticode>Microsoft400</Authenticode>
       </FilesToSign>
     </ItemGroup>


### PR DESCRIPTION
Fix for CI to be able to build V2 for Visual Studio insertion without signing errors (interfaces.js is an empty file, which breaks the signing process).