### PR TITLE
Add more variables tests for other scopes

### DIFF
--- a/test/int/featureBasedSuits/variablesScopes.test.ts
+++ b/test/int/featureBasedSuits/variablesScopes.test.ts
@@ -1,8 +1,3 @@
-/*---------------------------------------------------------------------------------------------
- *  Copyright (c) Microsoft Corporation. All rights reserved.
- *  Licensed under the MIT License. See License.txt in the project root for license information.
- *--------------------------------------------------------------------------------------------*/
-
 import { TestProjectSpec } from '../framework/frameworkTestSupport';
 import { VariablesWizard } from '../wizards/variables/variablesWizard';
 import { LaunchProject } from '../fixtures/launchProject';
@@ -42,5 +37,253 @@ suite('Variables scopes', function () {
                 str = "hello" (string)
                 xyz = 4 (number)`}
         );
+    });
+
+    testUsing('globals', context => LaunchProject.create(context, TestProjectSpec.fromTestPath('variablesScopes/globalScope')), async (launchProject) => {
+        await launchProject.pausedWizard.waitUntilPausedOnDebuggerStatement();
+
+        await new VariablesWizard(launchProject.debugClient).assertNewGlobalVariariablesAre(async () => {
+            await launchProject.pausedWizard.resume();
+            await launchProject.pausedWizard.waitUntilPausedOnDebuggerStatement();
+        },
+            // The variables declared with const, and let aren't global variables so they won't appear here
+            `
+            b = body {text: "", link: "", vLink: "", …} (Object)
+            bool = true (boolean)
+            buffer = ArrayBuffer(8) {} (Object)
+            buffView = Int32Array(2) [234, 0] (Object)
+            consoleDotLog = function consoleDotLog(m) { … } (Function)
+            e = Error: hi (Object)
+            element = p {align: "", title: "", lang: "", …} (Object)
+            evalVar1 = 16 (number)
+            evalVar2 = "sdlfk" (string)
+            evalVar3 = Array(3) [1, 2, 3] (Object)
+            fn = () => { … } (Function)
+            fn2 = function () { … } (Function)
+            globalCode = "page loaded" (string)
+            i = 101 (number)
+            inf = Infinity (number)
+            infStr = "Infinity" (string)
+            longStr = "this is a\nstring with\nnewlines" (string)
+            m = Map(1) {} (Object)
+            manyPropsObj = Object {0: 1, 1: 3, 2: 5, …} (Object)
+            myVar = Object {num: 1, str: "Global", obj: Object, …} (Object)
+            nan = NaN (number)
+            obj = Object {a: 2, thing: <accessor>} (Object)
+            qqq = undefined (undefined)
+            r = /^asdf.*$/g {lastIndex: 0} (Object) // TODO: This and other types seems wrong. Investigate
+            s = Symbol(hi) (symbol)
+            str = "hello" (string)
+            xyz = 4 (number)`);
+    });
+
+    testUsing('script', context => LaunchProject.create(context, TestProjectSpec.fromTestPath('variablesScopes/scriptScope')), async (launchProject) => {
+        await launchProject.pausedWizard.waitUntilPausedOnDebuggerStatement();
+
+        await new VariablesWizard(launchProject.debugClient).assertTopFrameVariablesAre({
+            script: `
+                this = Window (Object)
+                b = body {text: "", link: "", vLink: "", …} (Object)
+                bool = true (boolean)
+                buffer = ArrayBuffer(8) {} (Object)
+                buffView = Int32Array(2) [234, 0] (Object)
+                e = Error: hi (Object)
+                element = body {text: "", link: "", vLink: "", …} (Object)
+                fn = () => { … } (Function)
+                fn2 = function () { … } (Function)
+                globalCode = "page loaded" (string)
+                inf = Infinity (number)
+                infStr = "Infinity" (string)
+                longStr = "this is a\nstring with\nnewlines" (string)
+                m = Map(1) {} (Object)
+                manyPropsObj = Object {0: 1, 1: 3, 2: 5, …} (Object)
+                myVar = Object {num: 1, str: "Global", obj: Object, …} (Object)
+                nan = NaN (number)
+                obj = Object {a: 2, thing: <accessor>} (Object)
+                qqq = undefined (undefined)
+                r = /^asdf.*$/g {lastIndex: 0} (Object)
+                s = Symbol(hi) (symbol)
+                str = "hello" (string)
+                xyz = 4 (number)`}
+        );
+    });
+
+    testUsing('block', context => LaunchProject.create(context, TestProjectSpec.fromTestPath('variablesScopes/blockScope')), async (launchProject) => {
+        await launchProject.pausedWizard.waitUntilPausedOnDebuggerStatement();
+
+        await new VariablesWizard(launchProject.debugClient).assertTopFrameVariablesAre(
+            {
+                block: `
+                    this = Window (Object)
+                    b = body {text: "", link: "", vLink: "", …} (Object)
+                    bool = true (boolean)
+                    buffer = ArrayBuffer(8) {} (Object)
+                    buffView = Int32Array(2) [234, 0] (Object)
+                    consoleDotLog = function consoleDotLog(m) { … } (Function)
+                    e = Error: hi (Object)
+                    element = body {text: "", link: "", vLink: "", …} (Object)
+                    fn = () => { … } (Function)
+                    fn2 = function () { … } (Function)
+                    globalCode = "page loaded" (string)
+                    inf = Infinity (number)
+                    infStr = "Infinity" (string)
+                    longStr = "this is a\nstring with\nnewlines" (string)
+                    m = Map(1) {} (Object)
+                    manyPropsObj = Object {0: 1, 1: 3, 2: 5, …} (Object)
+                    myVar = Object {num: 1, str: "Global", obj: Object, …} (Object)
+                    nan = NaN (number)
+                    obj = Object {a: 2, thing: <accessor>} (Object)
+                    qqq = undefined (undefined)
+                    r = /^asdf.*$/g {lastIndex: 0} (Object)
+                    s = Symbol(hi) (symbol)
+                    str = "hello" (string)
+                    xyz = 4 (number)`
+            }
+        );
+    });
+
+    testUsing('catch', context => LaunchProject.create(context, TestProjectSpec.fromTestPath('variablesScopes/catchScope')), async (launchProject) => {
+        await launchProject.pausedWizard.waitUntilPausedOnDebuggerStatement();
+
+        await new VariablesWizard(launchProject.debugClient).assertTopFrameVariablesAre({
+            catch: `
+                exception = Error: Something went wrong (Object)`}
+        );
+    });
+
+    testUsing('closure', context => LaunchProject.create(context, TestProjectSpec.fromTestPath('variablesScopes/closureScope')), async (launchProject) => {
+        await launchProject.pausedWizard.waitUntilPausedOnDebuggerStatement();
+
+        await new VariablesWizard(launchProject.debugClient).assertTopFrameVariablesAre({
+            closure: `
+                arguments = Arguments(0) [] (Object)
+                b = body {text: "", link: "", vLink: "", …} (Object)
+                bool = true (boolean)
+                buffer = ArrayBuffer(8) {} (Object)
+                buffView = Int32Array(2) [234, 0] (Object)
+                consoleDotLog = function consoleDotLog(m) { … } (Function)
+                e = Error: hi (Object)
+                element = body {text: "", link: "", vLink: "", …} (Object)
+                fn = () => { … } (Function)
+                fn2 = function () { … } (Function)
+                globalCode = "page loaded" (string)
+                inf = Infinity (number)
+                infStr = "Infinity" (string)
+                longStr = "this is a\nstring with\nnewlines" (string)
+                m = Map(1) {} (Object)
+                manyPropsObj = Object {0: 1, 1: 3, 2: 5, …} (Object)
+                myVar = Object {num: 1, str: "Global", obj: Object, …} (Object)
+                nan = NaN (number)
+                obj = Object {a: 2, thing: <accessor>} (Object)
+                pauseInside = function pauseInside() { … } (Function)
+                qqq = undefined (undefined)
+                r = /^asdf.*$/g {lastIndex: 0} (Object)
+                s = Symbol(hi) (symbol)
+                str = "hello" (string)
+                xyz = 4 (number)`}
+        );
+    });
+
+    testUsing('eval', context => LaunchProject.create(context, TestProjectSpec.fromTestPath('variablesScopes/evalScope')), async (launchProject) => {
+        await launchProject.pausedWizard.waitUntilPausedOnDebuggerStatement();
+
+        await new VariablesWizard(launchProject.debugClient).assertTopFrameVariablesAre({
+            eval: `
+                this = Window (Object)
+                b = body {text: "", link: "", vLink: "", …} (Object)
+                bool = true (boolean)
+                buffer = ArrayBuffer(8) {} (Object)
+                buffView = Int32Array(2) [234, 0] (Object)
+                e = Error: hi (Object)
+                element = body {text: "", link: "", vLink: "", …} (Object)
+                fn = () => { … } (Function)
+                fn2 = function () { … } (Function)
+                globalCode = "page loaded" (string)
+                inf = Infinity (number)
+                infStr = "Infinity" (string)
+                longStr = "this is a\nstring with\nnewlines" (string)
+                m = Map(1) {} (Object)
+                manyPropsObj = Object {0: 1, 1: 3, 2: 5, …} (Object)
+                myVar = Object {num: 1, str: "Global", obj: Object, …} (Object)
+                nan = NaN (number)
+                obj = Object {a: 2, thing: <accessor>} (Object)
+                qqq = undefined (undefined)
+                r = /^asdf.*$/g {lastIndex: 0} (Object)
+                s = Symbol(hi) (symbol)
+                str = "hello" (string)
+                xyz = 4 (number)`}
+        );
+    });
+
+    testUsing('with', context => LaunchProject.create(context, TestProjectSpec.fromTestPath('variablesScopes/withScope')), async (launchProject) => {
+        await launchProject.pausedWizard.waitUntilPausedOnDebuggerStatement();
+
+        await new VariablesWizard(launchProject.debugClient).assertTopFrameVariablesAre({
+            with: `
+                this = Window (Object)
+                b = body {text: "", link: "", vLink: "", …} (Object)
+                bool = true (boolean)
+                buffer = ArrayBuffer(8) {} (Object)
+                buffView = Int32Array(2) [234, 0] (Object)
+                consoleDotLog = function (m) { … } (Function)
+                e = Error: hi (Object)
+                element = body {text: "", link: "", vLink: "", …} (Object)
+                evalVar1 = 16 (number)
+                evalVar2 = "sdlfk" (string)
+                evalVar3 = Array(3) [1, 2, 3] (Object)
+                fn = () => { … } (Function)
+                fn2 = function () { … } (Function)
+                globalCode = "page loaded" (string)
+                i = 101 (number)
+                inf = Infinity (number)
+                infStr = "Infinity" (string)
+                longStr = "this is a
+                string with
+                newlines" (string)
+                m = Map(1) {} (Object)
+                manyPropsObj = Object {0: 1, 1: 3, 2: 5, …} (Object)
+                myVar = Object {num: 1, str: "Global", obj: Object, …} (Object)
+                nan = NaN (number)
+                obj = Object {a: 2, thing: <accessor>} (Object)
+                r = /^asdf.*$/g {lastIndex: 0} (Object)
+                s = Symbol(hi) (symbol)
+                str = "hello" (string)
+                xyz = 4 (number)
+                __proto__ = Object {constructor: , __defineGetter__: , __defineSetter__: , …} (Object)`
+        });
+    });
+
+    testUsing('module', context => LaunchProject.create(context, TestProjectSpec.fromTestPath('variablesScopes/moduleScope')), async (launchProject) => {
+        await launchProject.pausedWizard.waitUntilPausedOnDebuggerStatement();
+
+        await new VariablesWizard(launchProject.debugClient).assertTopFrameVariablesAre({
+            module: `
+                this = undefined (undefined)
+                b = body {text: "", link: "", vLink: "", …} (Object)
+                bool = true (boolean)
+                buffer = ArrayBuffer(8) {} (Object)
+                buffView = Int32Array(2) [234, 0] (Object)
+                consoleDotLog = function consoleDotLog(m2) { … } (Function)
+                e = Error: hi (Object)
+                element = body {text: "", link: "", vLink: "", …} (Object)
+                fn = () => { … } (Function)
+                fn2 = function (param) { … } (Function)
+                globalCode = "page loaded" (string)
+                inf = Infinity (number)
+                infStr = "Infinity" (string)
+                longStr = "this is a
+                string with
+                newlines" (string)
+                m = Map(1) {} (Object)
+                manyPropsObj = Object {0: 1, 1: 3, 2: 5, …} (Object)
+                myVar = Object {num: 1, str: "Global", obj: Object, …} (Object)
+                nan = NaN (number)
+                obj = Object {a: 2, thing: <accessor>} (Object)
+                qqq = undefined (undefined)
+                r = /^asdf.*$/g {lastIndex: 0} (Object)
+                s = Symbol(hi) (symbol)
+                str = "hello" (string)
+                xyz = 4 (number)`
+        });
     });
 });

--- a/testdata/variablesScopes/.vscode/launch.json
+++ b/testdata/variablesScopes/.vscode/launch.json
@@ -1,0 +1,16 @@
+{
+    // Use IntelliSense to learn about possible attributes.
+    // Hover to view descriptions of existing attributes.
+    // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
+    "version": "0.2.0",
+    "configurations": [
+        {
+            "type": "chrome",
+            "request": "launch",
+            "name": "Launch Chrome against localhost",
+            "url": "http://localhost:8080",
+            "webRoot": "${workspaceFolder}",
+            // "debugServer": 4712
+        }
+    ]
+}

--- a/testdata/variablesScopes/blockScope/blockVariablesApp.js
+++ b/testdata/variablesScopes/blockScope/blockVariablesApp.js
@@ -1,0 +1,83 @@
+(function () {
+    console.log('TestCode: START');
+    let i;
+    for (i = 7; i < 10; ++i) {
+        console.log('TestCode: BEFORE-ADDING-VARIABLES');
+
+        // Try to create a variable of each important type, to verify that we can see their contents properly
+
+        const globalCode = 'page loaded';
+
+        function consoleDotLog(m) {
+            console.log(m)
+        }
+
+        const manyPropsObj = { prop2: 'abc', prop1: 'def' };
+        for (let i = 0; i <= 100; i++) manyPropsObj[i] = 2 * i + 1;
+
+        let r = /^asdf.*$/g;
+        let longStr = `this is a
+string with
+newlines`;
+        let element = document.body;
+        const buffer = new ArrayBuffer(8);
+        let buffView = new Int32Array(buffer);
+        buffView[0] = 234;
+        let s = Symbol('hi');
+        let e = new Error('hi');
+
+        let m = new Map();
+        m.set('a', 1);
+
+        let b = document.body;
+        const nan = NaN;
+        let inf = 1 / 0;
+        let infStr = "Infinity";
+
+        // These 3 are going to be global variables
+        eval('let evalVar3 = [1,2,3]');
+        eval('let evalVar1 = 16');
+        eval('let evalVar2 = "sdlfk"');
+
+        let bool = true;
+        const fn = () => {
+            // Some fn
+            let xyz = 321;
+            anotherFn();
+        };
+        let fn2 = function () {
+            let zzz = 333;
+        };
+        let qqq;
+        let str = 'hello';
+        let xyz = 1;
+        let obj = { a: 2, get thing() { throw 'xyz'; }, set thing(x) { } };
+        xyz++; xyz++; xyz++;
+
+        let myVar = {
+            num: 1,
+            str: "Global",
+
+            obj: {
+                obj: {
+                    obj: { num: 10 },
+                    obj2: { obj3: {} },
+                }
+            },
+            obj2: {
+                obj3: {}
+            },
+
+        }
+
+        myVar["self"] = myVar;
+        myVar.obj["toMyVar"] = myVar;
+
+
+        console.log('TestCode: BEFORE-VERIFYING-VARIABLES');
+
+        debugger; // Pause here to verify that we can see the values and types of all the variables
+        break;
+    }
+    console.log('TestCode: END');
+})();

--- a/testdata/variablesScopes/blockScope/index.html
+++ b/testdata/variablesScopes/blockScope/index.html
@@ -1,0 +1,10 @@
+<!doctype html>
+<html>
+  <head>
+  </head>
+  <body>
+    <h1>Hello, world!</h1>
+    <span id='#pageLoadedSuccesfully'>Page loaded succesfully</span>
+    <script src="blockVariablesApp.js"></script>
+  </body>
+</html>

--- a/testdata/variablesScopes/catchScope/.vscode/launch.json
+++ b/testdata/variablesScopes/catchScope/.vscode/launch.json
@@ -1,0 +1,15 @@
+{
+    // Use IntelliSense to learn about possible attributes.
+    // Hover to view descriptions of existing attributes.
+    // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
+    "version": "0.2.0",
+    "configurations": [
+        {
+            "type": "chrome",
+            "request": "launch",
+            "name": "Launch Chrome against localhost",
+            "url": "http://localhost:8080",
+            "webRoot": "${workspaceFolder}"
+        }
+    ]
+}

--- a/testdata/variablesScopes/catchScope/catchVariablesApp.js
+++ b/testdata/variablesScopes/catchScope/catchVariablesApp.js
@@ -1,0 +1,84 @@
+(function () {
+    console.log('TestCode: START');
+    console.log('TestCode: BEFORE-ADDING-VARIABLES');
+    try {
+        throw new Error('Something went wrong');
+    } catch (exception) {
+
+        // Try to create a variable of each important type, to verify that we can see their contents properly
+
+        const globalCode = 'page loaded';
+
+        function consoleDotLog(m) {
+            console.log(m)
+        }
+
+        const manyPropsObj = { prop2: 'abc', prop1: 'def' };
+        for (let i = 0; i <= 100; i++) manyPropsObj[i] = 2 * i + 1;
+
+        let r = /^asdf.*$/g;
+        let longStr = `this is a
+string with
+newlines`;
+        let element = document.body;
+        const buffer = new ArrayBuffer(8);
+        let buffView = new Int32Array(buffer);
+        buffView[0] = 234;
+        let s = Symbol('hi');
+        let e = new Error('hi');
+
+        let m = new Map();
+        m.set('a', 1);
+
+        let b = document.body;
+        const nan = NaN;
+        let inf = 1 / 0;
+        let infStr = "Infinity";
+
+        // These 3 are going to be global variables
+        eval('let evalVar3 = [1,2,3]');
+        eval('let evalVar1 = 16');
+        eval('let evalVar2 = "sdlfk"');
+
+        let bool = true;
+        const fn = () => {
+            // Some fn
+            let xyz = 321;
+            anotherFn();
+        };
+        let fn2 = function () {
+            let zzz = 333;
+        };
+        let qqq;
+        let str = 'hello';
+        let xyz = 1;
+        let obj = { a: 2, get thing() { throw 'xyz'; }, set thing(x) { } };
+        xyz++; xyz++; xyz++;
+
+        let myVar = {
+            num: 1,
+            str: "Global",
+
+            obj: {
+                obj: {
+                    obj: { num: 10 },
+                    obj2: { obj3: {} },
+                }
+            },
+            obj2: {
+                obj3: {}
+            },
+
+        }
+
+        myVar["self"] = myVar;
+        myVar.obj["toMyVar"] = myVar;
+
+
+        console.log('TestCode: BEFORE-VERIFYING-VARIABLES');
+
+        debugger; // Pause here to verify that we can see the values and types of all the variables
+
+        console.log('TestCode: END');
+    }
+})();

--- a/testdata/variablesScopes/catchScope/index.html
+++ b/testdata/variablesScopes/catchScope/index.html
@@ -1,0 +1,10 @@
+<!doctype html>
+<html>
+  <head>
+  </head>
+  <body>
+    <h1>Hello, world!</h1>
+    <span id='#pageLoadedSuccesfully'>Page loaded succesfully</span>
+    <script src="catchVariablesApp.js"></script>
+  </body>
+</html>

--- a/testdata/variablesScopes/closureScope/closureVariablesApp.js
+++ b/testdata/variablesScopes/closureScope/closureVariablesApp.js
@@ -1,0 +1,84 @@
+(function () {
+    console.log('TestCode: START');
+    console.log('TestCode: BEFORE-ADDING-VARIABLES');
+
+    // Try to create a variable of each important type, to verify that we can see their contents properly
+
+    const globalCode = 'page loaded';
+
+    function consoleDotLog(m) {
+        console.log(m)
+    }
+
+    const manyPropsObj = { prop2: 'abc', prop1: 'def' };
+    for (let i = 0; i <= 100; i++) manyPropsObj[i] = 2 * i + 1;
+
+    let r = /^asdf.*$/g;
+    let longStr = `this is a
+string with
+newlines`;
+    let element = document.body;
+    const buffer = new ArrayBuffer(8);
+    let buffView = new Int32Array(buffer);
+    buffView[0] = 234;
+    let s = Symbol('hi');
+    let e = new Error('hi');
+
+    let m = new Map();
+    m.set('a', 1);
+
+    let b = document.body;
+    const nan = NaN;
+    let inf = 1 / 0;
+    let infStr = "Infinity";
+
+    // These 3 are going to be global variables
+    eval('let evalVar3 = [1,2,3]');
+    eval('let evalVar1 = 16');
+    eval('let evalVar2 = "sdlfk"');
+
+    let bool = true;
+    const fn = () => {
+        // Some fn
+        let xyz = 321;
+        anotherFn();
+    };
+    let fn2 = function () {
+        let zzz = 333;
+    };
+    let qqq;
+    let str = 'hello';
+    let xyz = 1;
+    let obj = { a: 2, get thing() { throw 'xyz'; }, set thing(x) { } };
+    xyz++; xyz++; xyz++;
+
+    let myVar = {
+        num: 1,
+        str: "Global",
+
+        obj: {
+            obj: {
+                obj: { num: 10 },
+                obj2: { obj3: {} },
+            }
+        },
+        obj2: {
+            obj3: {}
+        },
+
+    }
+
+    myVar["self"] = myVar;
+    myVar.obj["toMyVar"] = myVar;
+
+
+    console.log('TestCode: BEFORE-VERIFYING-VARIABLES');
+
+    const pauseInside = function pauseInside() {
+        debugger; // Pause here to verify that we can see the values and types of all the variables
+    }
+    
+    pauseInside();
+
+    console.log('TestCode: END');
+})();

--- a/testdata/variablesScopes/closureScope/index.html
+++ b/testdata/variablesScopes/closureScope/index.html
@@ -1,0 +1,10 @@
+<!doctype html>
+<html>
+  <head>
+  </head>
+  <body>
+    <h1>Hello, world!</h1>
+    <span id='#pageLoadedSuccesfully'>Page loaded succesfully</span>
+    <script src="closureVariablesApp.js"></script>
+  </body>
+</html>

--- a/testdata/variablesScopes/evalScope/evalVariablesApp.js
+++ b/testdata/variablesScopes/evalScope/evalVariablesApp.js
@@ -1,0 +1,81 @@
+console.log('TestCode: START');
+
+console.log('TestCode: BEFORE-ADDING-VARIABLES');
+
+// Try to create a variable of each important type, to verify that we can see their contents properly
+
+eval(`
+const globalCode = 'page loaded';
+
+function consoleDotLog(m) {
+    console.log(m)
+}
+
+const manyPropsObj = { prop2: 'abc', prop1: 'def' };
+for (let i = 0; i <= 100; i++) manyPropsObj[i] = 2 * i + 1;
+
+let r = /^asdf.*$/g;
+let longStr = \`this is a
+string with
+newlines\`;
+let element = document.body;
+const buffer = new ArrayBuffer(8);
+let buffView = new Int32Array(buffer);
+buffView[0] = 234;
+let s = Symbol('hi');
+let e = new Error('hi');
+
+let m = new Map();
+m.set('a', 1);
+
+let b = document.body;
+const nan = NaN;
+let inf = 1 / 0;
+let infStr = "Infinity";
+
+// These 3 are going to be global variables
+eval('let evalVar3 = [1,2,3]');
+eval('let evalVar1 = 16');
+eval('let evalVar2 = "sdlfk"');
+
+let bool = true;
+const fn = () => {
+    // Some fn
+    let xyz = 321;
+    anotherFn();
+};
+let fn2 = function () {
+    let zzz = 333;
+};
+let qqq;
+let str = 'hello';
+let xyz = 1;
+let obj = { a: 2, get thing() { throw 'xyz'; }, set thing(x) { } };
+xyz++; xyz++; xyz++;
+
+let myVar = {
+    num: 1,
+    str: "Global",
+
+    obj: {
+        obj: {
+            obj: { num: 10 },
+            obj2: { obj3: {} },
+        }
+    },
+    obj2: {
+        obj3: {}
+    },
+
+}
+
+myVar["self"] = myVar;
+myVar.obj["toMyVar"] = myVar;
+
+
+console.log('TestCode: BEFORE-VERIFYING-VARIABLES');
+
+debugger; // Pause here to verify that we can see the values and types of all the variables
+`);
+
+console.log('TestCode: END');

--- a/testdata/variablesScopes/evalScope/index.html
+++ b/testdata/variablesScopes/evalScope/index.html
@@ -1,0 +1,10 @@
+<!doctype html>
+<html>
+  <head>
+  </head>
+  <body>
+    <h1>Hello, world!</h1>
+    <span id='#pageLoadedSuccesfully'>Page loaded succesfully</span>
+    <script src="evalVariablesApp.js"></script>
+  </body>
+</html>

--- a/testdata/variablesScopes/globalScope/globalVariablesApp.js
+++ b/testdata/variablesScopes/globalScope/globalVariablesApp.js
@@ -1,0 +1,81 @@
+console.log('TestCode: START');
+
+debugger; // Pause here to get a list of all the "existing" global variables, so we know to ignore those
+
+console.log('TestCode: BEFORE-ADDING-VARIABLES');
+
+// Try to create a variable of each important type, to verify that we can see their contents properly
+
+eval(`
+var globalCode = 'page loaded';
+
+function consoleDotLog(m) {
+    console.log(m)
+}
+
+var manyPropsObj = { prop2: 'abc', prop1: 'def' };
+for (var i = 0; i <= 100; i++) manyPropsObj[i] = 2 * i + 1;
+
+var r = /^asdf.*$/g;
+var longStr = \`this is a
+string with
+newlines\`;
+var element = document.createElement("p");
+var buffer = new ArrayBuffer(8);
+var buffView = new Int32Array(buffer);
+buffView[0] = 234;
+var s = Symbol('hi');
+var e = new Error('hi');
+
+var m = new Map();
+m.set('a', 1);
+
+var b = document.body;
+var nan = NaN;
+var inf = 1 / 0;
+var infStr = "Infinity";
+
+eval('var evalVar3 = [1,2,3]');
+eval('var evalVar1 = 16');
+eval('var evalVar2 = "sdlfk"');
+
+var bool = true;
+var fn = () => {
+    // Some fn
+    var xyz = 321;
+    anotherFn();
+};
+var fn2 = function () {
+    var zzz = 333;
+};
+var qqq;
+var str = 'hello';
+var xyz = 1;
+var obj = { a: 2, get thing() { throw 'xyz'; }, set thing(x) { } };
+xyz++; xyz++; xyz++;
+
+var myVar = {
+    num: 1,
+    str: "Global",
+
+    obj: {
+        obj: {
+            obj: { num: 10 },
+            obj2: { obj3: {} },
+        }
+    },
+    obj2: {
+        obj3: {}
+    },
+
+}
+
+myVar["self"] = myVar;
+myVar.obj["toMyVar"] = myVar;
+`);
+
+console.log('TestCode: BEFORE-VERIFYING-VARIABLES');
+
+debugger; // Pause here to verify that we can see the values and types of all the variables
+
+console.log('TestCode: END');

--- a/testdata/variablesScopes/globalScope/index.html
+++ b/testdata/variablesScopes/globalScope/index.html
@@ -1,0 +1,10 @@
+<!doctype html>
+<html>
+  <head>
+  </head>
+  <body>
+    <h1>Hello, world!</h1>
+    <span id='#pageLoadedSuccesfully'>Page loaded succesfully</span>
+    <script src="globalVariablesApp.js"></script>
+  </body>
+</html>

--- a/testdata/variablesScopes/moduleScope/index.html
+++ b/testdata/variablesScopes/moduleScope/index.html
@@ -1,0 +1,10 @@
+<!doctype html>
+<html>
+  <head>
+  </head>
+  <body>
+    <h1>Hello, world!</h1>
+    <span id='#pageLoadedSuccesfully'>Page loaded succesfully</span>
+    <script type="module" src="moduleVariablesApp.js"></script>
+  </body>
+</html>

--- a/testdata/variablesScopes/moduleScope/moduleVariablesApp.js
+++ b/testdata/variablesScopes/moduleScope/moduleVariablesApp.js
@@ -1,0 +1,62 @@
+console.log('TestCode: START');
+console.log('TestCode: BEFORE-ADDING-VARIABLES');
+// Try to create a variable of each important type, to verify that we can see their contents properly
+export const globalCode = 'page loaded';
+function consoleDotLog(m2) {
+    console.log(m2);
+}
+export const manyPropsObj = { prop2: 'abc', prop1: 'def' };
+for (let i = 0; i <= 100; i++)
+    manyPropsObj[i] = 2 * i + 1;
+export let r = /^asdf.*$/g;
+export let longStr = `this is a
+string with
+newlines`;
+export let element = document.body;
+export const buffer = new ArrayBuffer(8);
+export let buffView = new Int32Array(buffer);
+buffView[0] = 234;
+export let s = Symbol('hi');
+export let e = new Error('hi');
+export let m = new Map();
+m.set('a', 1);
+export let b = document.body;
+export const nan = NaN;
+export let inf = 1 / 0;
+export let infStr = 'Infinity';
+export let bool = true;
+export const fn = () => {
+    // Some fn
+    let xyzz = 321;
+    fn2(xyzz);
+};
+export let fn2 = function (param) {
+    let zzz = 333;
+    return param + zzz;
+};
+export let qqq;
+export let str = 'hello';
+export let xyz = 1;
+export let obj = { a: 2, get thing() { throw 'xyz'; }, set thing(x) { } };
+xyz++;
+xyz++;
+xyz++;
+export let myVar = {
+    num: 1,
+    str: 'Global',
+    obj: {
+        obj: {
+            obj: { num: 10 },
+            obj2: { obj3: {} },
+        }
+    },
+    obj2: {
+        obj3: {}
+    },
+};
+myVar['self'] = myVar;
+myVar.obj['toMyVar'] = myVar;
+console.log('TestCode: BEFORE-VERIFYING-VARIABLES');
+// tslint:disable-next-line: no-debugger
+debugger; // Pause here to verify that we can see the values and types of all the variables
+console.log('TestCode: END');

--- a/testdata/variablesScopes/moduleScope/moduleVariablesApp.ts
+++ b/testdata/variablesScopes/moduleScope/moduleVariablesApp.ts
@@ -1,0 +1,75 @@
+console.log('TestCode: START');
+console.log('TestCode: BEFORE-ADDING-VARIABLES');
+
+// Try to create a variable of each important type, to verify that we can see their contents properly
+
+export const globalCode = 'page loaded';
+
+function consoleDotLog(m2: string) {
+    console.log(m2);
+}
+
+export const manyPropsObj = { prop2: 'abc', prop1: 'def' };
+for (let i = 0; i <= 100; i++) manyPropsObj[i] = 2 * i + 1;
+
+export let r = /^asdf.*$/g;
+export let longStr = `this is a
+string with
+newlines`;
+export let element = document.body;
+export const buffer = new ArrayBuffer(8);
+export let buffView = new Int32Array(buffer);
+buffView[0] = 234;
+export let s = Symbol('hi');
+export let e = new Error('hi');
+
+export let m = new Map();
+m.set('a', 1);
+
+export let b = document.body;
+export const nan = NaN;
+export let inf = 1 / 0;
+export let infStr = 'Infinity';
+
+export let bool = true;
+export const fn = () => {
+    // Some fn
+    let xyzz = 321;
+    fn2(xyzz);
+};
+export let fn2 = function (param) {
+    let zzz = 333;
+    return param + zzz;
+};
+export let qqq;
+export let str = 'hello';
+export let xyz = 1;
+export let obj = { a: 2, get thing() { throw 'xyz'; }, set thing(x) { } };
+xyz++; xyz++; xyz++;
+
+export let myVar = {
+    num: 1,
+    str: 'Global',
+
+    obj: {
+        obj: {
+            obj: { num: 10 },
+            obj2: { obj3: {} },
+        }
+    },
+    obj2: {
+        obj3: {}
+    },
+
+};
+
+myVar['self'] = myVar;
+myVar.obj['toMyVar'] = myVar;
+
+
+console.log('TestCode: BEFORE-VERIFYING-VARIABLES');
+
+// tslint:disable-next-line: no-debugger
+debugger; // Pause here to verify that we can see the values and types of all the variables
+
+console.log('TestCode: END');

--- a/testdata/variablesScopes/moduleScope/tsconfig.json
+++ b/testdata/variablesScopes/moduleScope/tsconfig.json
@@ -1,0 +1,5 @@
+{
+    "compilerOptions": {
+        "target": "es6"
+    }
+}

--- a/testdata/variablesScopes/scriptScope/index.html
+++ b/testdata/variablesScopes/scriptScope/index.html
@@ -1,0 +1,10 @@
+<!doctype html>
+<html>
+  <head>
+  </head>
+  <body>
+    <h1>Hello, world!</h1>
+    <span id='#pageLoadedSuccesfully'>Page loaded succesfully</span>
+    <script src="scriptVariablesApp.js"></script>
+  </body>
+</html>

--- a/testdata/variablesScopes/scriptScope/scriptVariablesApp.js
+++ b/testdata/variablesScopes/scriptScope/scriptVariablesApp.js
@@ -1,0 +1,78 @@
+console.log('TestCode: START');
+console.log('TestCode: BEFORE-ADDING-VARIABLES');
+
+// Try to create a variable of each important type, to verify that we can see their contents properly
+
+const globalCode = 'page loaded';
+
+function consoleDotLog(m) {
+    console.log(m)
+}
+
+const manyPropsObj = { prop2: 'abc', prop1: 'def' };
+for (let i = 0; i <= 100; i++) manyPropsObj[i] = 2 * i + 1;
+
+let r = /^asdf.*$/g;
+let longStr = `this is a
+string with
+newlines`;
+let element = document.body;
+const buffer = new ArrayBuffer(8);
+let buffView = new Int32Array(buffer);
+buffView[0] = 234;
+let s = Symbol('hi');
+let e = new Error('hi');
+
+let m = new Map();
+m.set('a', 1);
+
+let b = document.body;
+const nan = NaN;
+let inf = 1 / 0;
+let infStr = "Infinity";
+
+// These 3 are going to be global variables
+eval('let evalVar3 = [1,2,3]');
+eval('let evalVar1 = 16');
+eval('let evalVar2 = "sdlfk"');
+
+let bool = true;
+const fn = () => {
+    // Some fn
+    let xyz = 321;
+    anotherFn();
+};
+let fn2 = function () {
+    let zzz = 333;
+};
+let qqq;
+let str = 'hello';
+let xyz = 1;
+let obj = { a: 2, get thing() { throw 'xyz'; }, set thing(x) { } };
+xyz++; xyz++; xyz++;
+
+let myVar = {
+    num: 1,
+    str: "Global",
+
+    obj: {
+        obj: {
+            obj: { num: 10 },
+            obj2: { obj3: {} },
+        }
+    },
+    obj2: {
+        obj3: {}
+    },
+
+}
+
+myVar["self"] = myVar;
+myVar.obj["toMyVar"] = myVar;
+
+
+console.log('TestCode: BEFORE-VERIFYING-VARIABLES');
+
+debugger; // Pause here to verify that we can see the values and types of all the variables
+
+console.log('TestCode: END');

--- a/testdata/variablesScopes/withScope/index.html
+++ b/testdata/variablesScopes/withScope/index.html
@@ -1,0 +1,10 @@
+<!doctype html>
+<html>
+  <head>
+  </head>
+  <body>
+    <h1>Hello, world!</h1>
+    <span id='#pageLoadedSuccesfully'>Page loaded succesfully</span>
+    <script src="withVariablesApp.js"></script>
+  </body>
+</html>

--- a/testdata/variablesScopes/withScope/withVariablesApp.js
+++ b/testdata/variablesScopes/withScope/withVariablesApp.js
@@ -1,0 +1,81 @@
+(function () {
+    console.log('TestCode: START');
+    console.log('TestCode: BEFORE-ADDING-VARIABLES');
+
+    // Try to create a variable of each important type, to verify that we can see their contents properly
+
+    const locals = {};
+    locals.globalCode = 'page loaded';
+
+    locals.consoleDotLog = function (m) {
+        console.log(m)
+    }
+
+    locals.manyPropsObj = { prop2: 'abc', prop1: 'def' };
+    for (locals.i = 0; locals.i <= 100; locals.i++) locals.manyPropsObj[locals.i] = 2 * locals.i + 1;
+
+    locals.r = /^asdf.*$/g;
+    locals.longStr = `this is a
+string with
+newlines`;
+    locals.element = document.body;
+    locals.buffer = new ArrayBuffer(8);
+    locals.buffView = new Int32Array(locals.buffer);
+    locals.buffView[0] = 234;
+    locals.s = Symbol('hi');
+    locals.e = new Error('hi');
+
+    locals.m = new Map();
+    locals.m.set('a', 1);
+
+    locals.b = document.body;
+    locals.nan = NaN;
+    locals.inf = 1 / 0;
+    locals.infStr = "Infinity";
+
+    // These 3 are going to be global variables
+    eval('locals.evalVar3 = [1,2,3]');
+    eval('locals.evalVar1 = 16');
+    eval('locals.evalVar2 = "sdlfk"');
+
+    locals.bool = true;
+    locals.fn = () => {
+        // Some fn
+        locals.xyz = 321;
+        anotherFn();
+    };
+    locals.fn2 = function () {
+        locals.zzz = 333;
+    };
+    locals.qqq;
+    locals.str = 'hello';
+    locals.xyz = 1;
+    locals.obj = { a: 2, get thing() { throw 'xyz'; }, set thing(x) { } };
+    locals.xyz++; locals.xyz++; locals.xyz++;
+
+    locals.myVar = {
+        num: 1,
+        str: "Global",
+
+        obj: {
+            obj: {
+                obj: { num: 10 },
+                obj2: { obj3: {} },
+            }
+        },
+        obj2: {
+            obj3: {}
+        },
+
+    }
+
+    locals.myVar["self"] = locals.myVar;
+    locals.myVar.obj["toMyVar"] = locals.myVar;
+
+    console.log('TestCode: BEFORE-VERIFYING-VARIABLES');
+
+    with (locals) {
+        debugger; // Pause here to verify that we can see the values and types of all the variables
+    }
+    log('TestCode: END');
+})();


### PR DESCRIPTION
Add more variables tests for other scopes
We test the same basic set of variable types in each of the possible scopes

```
Variables scopes
    √ local
    √ globals
    √ script
    √ block
    √ catch
    √ closure
    √ eval
    √ with
    √ module

```