### PR TITLE
Adapt to changes in core

### DIFF
--- a/src/chromeDebug.ts
+++ b/src/chromeDebug.ts
@@ -4,7 +4,7 @@
 
 import * as os from 'os';
 import * as path from 'path';
-import { ChromeDebugSession, logger, OnlyProvideCustomLauncherExtensibilityPoints, ISourcesRetriever, telemetry, UrlPathTransformer, TYPES, interfaces, GetComponentByID, DependencyInjection, UninitializedCDA } from 'vscode-chrome-debug-core';
+import { ChromeDebugSession, logger, OnlyProvideCustomLauncherExtensibilityPoints, ISourcesRetriever, telemetry, UrlPathTransformer, TYPES, interfaces, GetComponentByID, DependencyInjection, UninitializedCDA, ISession } from 'vscode-chrome-debug-core';
 import { ChromeDebugAdapter } from './chromeDebugAdapter';
 import { ChromeLauncher } from './launcherAndRuner/chromeLauncher';
 import { defaultTargetFilter } from './utils';
@@ -28,7 +28,8 @@ function customizeComponents<T>(identifier: interfaces.ServiceIdentifier<T>, com
             return <T><unknown>new HTMLSourceRetriever(<ISourcesRetriever><unknown>component, getComponentById(CDTPResourceContentGetter));
             case TYPES.UninitializedCDA:
             // We use our own version of the UninitializedCDA component to declare some extra capabilities that this client supports
-            return <T><unknown>new CustomizedUninitializedCDA(<UninitializedCDA><unknown>component);
+            const session = <ISession>getComponentById(TYPES.ISession);
+            return <T><unknown>new CustomizedUninitializedCDA(session, <UninitializedCDA><unknown>component);
         default:
             return component;
     }

--- a/src/components/customizedUninitializedCDA.ts
+++ b/src/components/customizedUninitializedCDA.ts
@@ -2,7 +2,7 @@
  * Copyright (C) Microsoft Corporation. All rights reserved.
  *--------------------------------------------------------*/
 
-import { BaseCDAState, injectable, IInitializeRequestArgs, UninitializedCDA, ITelemetryPropertyCollector, IDebugAdapterState } from 'vscode-chrome-debug-core';
+import { BaseCDAState, injectable, IInitializeRequestArgs, UninitializedCDA, ITelemetryPropertyCollector, IDebugAdapterState, inject, TYPES, ISession } from 'vscode-chrome-debug-core';
 import { DebugProtocol } from 'vscode-debugprotocol';
 
 /**
@@ -11,6 +11,7 @@ import { DebugProtocol } from 'vscode-debugprotocol';
 @injectable()
 export class CustomizedUninitializedCDA extends BaseCDAState {
     constructor(
+        @inject(TYPES.ISession) protected readonly _session: ISession,
         private readonly _wrappedUninitializedCDA: UninitializedCDA) {
         super([], { 'initialize': (args, telemetryPropertyCollector) => this.initialize(args, telemetryPropertyCollector) });
     }


### PR DESCRIPTION
Adapt to the changes in -core made in this PR: https://github.com/microsoft/vscode-chrome-debug-core/pull/454

Now all the CDAStates need to have a _session: ISession property.