### PR TITLE
Don't kill chrome when disconnected from websocket

### DIFF
--- a/.vsts/job.yml
+++ b/.vsts/job.yml
@@ -8,9 +8,9 @@ jobs:
     vmImage: ${{ parameters.vmImage }}
   steps:
   - task: NodeTool@0
-    displayName: Use Node 8.x
+    displayName: Use Node 10.x
     inputs:
-      versionSpec: 8.x
+      versionSpec: 10.x
       checkLatest: true
 
   - ${{ if eq(parameters.name, 'Windows') }}:


### PR DESCRIPTION
This PR requires this change in -core: https://github.com/microsoft/vscode-chrome-debug-core/pull/461

Chrome was showing a message: "Chrome didn't finish properly, and you need to restore pages" when closing chrome directly instead of stopping the debug session from VS.

I found some comments from v1 that mention that we shouldn't be killing Chrome when we close due to the websocket, and it also makes sense... I'm modifying the code to pass the TerminatingReason to IDebuggeeLauncher, so we don't kill chrome when we are stopping because we disconnected from the websocket. That solves the issue