### PR TITLE
Add test to verify we show the proper error for invalid JS

### DIFF
--- a/test/int/featureBasedSuits/invalidJavaScriptCode.test.ts
+++ b/test/int/featureBasedSuits/invalidJavaScriptCode.test.ts
@@ -1,0 +1,33 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { testUsing } from '../fixtures/testUsing';
+import { TestProjectSpec } from '../framework/frameworkTestSupport';
+import { LaunchProject } from '../fixtures/launchProject';
+import { onUnhandledException, onHandledError } from '../utils/onUnhandledException';
+import { utils } from 'vscode-chrome-debug-core';
+
+const waitForTestResult = utils.promiseDefer();
+
+testUsing('No unhandled exceptions when we parse invalid JavaScript code. We get a handled error', context => LaunchProject.launch(context,
+    TestProjectSpec.fromTestPath('featuresTests/invalidJavaScriptCode'), {},
+    {
+        registerListeners: client => {
+            // We fail the test if we get an unhandled exception
+            onUnhandledException(client, exceptionMessage => waitForTestResult.reject(exceptionMessage));
+            // We expect to get a handled error instead
+            onHandledError(client, async errorMessage => {
+                if (errorMessage.startsWith(`SyntaxError: Unexpected token 'function'`)) {
+                    // After we get the message, we wait 1 more second to verify we don't get any unhandled exceptions, and then we succeed the test
+                    await utils.promiseTimeout(undefined, 1000 /* 1 sec */);
+
+                    waitForTestResult.resolve();
+                }
+            });
+        }
+    }),
+    async (_launchProject) => {
+        await waitForTestResult.promise;
+    });

--- a/test/int/utils/onUnhandledException.ts
+++ b/test/int/utils/onUnhandledException.ts
@@ -1,0 +1,18 @@
+import { DebugClient } from 'vscode-debugadapter-testsupport';
+import { DebugProtocol } from 'vscode-debugprotocol';
+
+export function onUnhandledException(client: DebugClient, actionWhenUnhandledException: (exceptionMessage: string) => void): void {
+    client.on('output', (args: DebugProtocol.OutputEvent) => {
+        if (args.body.category === 'telemetry' && args.body.output === 'error') {
+            actionWhenUnhandledException(`Debug adapter had an unhandled error: ${args.body.data.exceptionMessage}`);
+        }
+    });
+}
+
+export function onHandledError(client: DebugClient, actionWhenHandledError: (exceptionMessage: string) => void): void {
+    client.on('output', (args: DebugProtocol.OutputEvent) => {
+        if (args.body.category === 'stderr') {
+            actionWhenHandledError(args.body.output);
+        }
+    });
+}

--- a/testdata/featuresTests/invalidJavaScriptCode/.vscode/launch.json
+++ b/testdata/featuresTests/invalidJavaScriptCode/.vscode/launch.json
@@ -1,0 +1,24 @@
+{
+    // Use IntelliSense to learn about possible attributes.
+    // Hover to view descriptions of existing attributes.
+    // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
+    "version": "0.2.0",
+    "configurations": [
+        {
+            "type": "chrome",
+            "request": "launch",
+            "name": "Launch Chrome",
+            "url": "http://localhost:8080",
+            "webRoot": "${workspaceFolder}"
+        },
+        {
+            "type": "chrome",
+            "request": "launch",
+            "name": "Launch Chrome (Port: 4712)",
+            "url": "http://localhost:8080",
+            "webRoot": "${workspaceFolder}",
+            "debugServer": 4712
+        }
+
+    ]
+}

--- a/testdata/featuresTests/invalidJavaScriptCode/app.js
+++ b/testdata/featuresTests/invalidJavaScriptCode/app.js
@@ -1,0 +1,6 @@
+function function runCode() {
+}
+
+runCode();
+
+console.log(`I'm surprised the runtime made it here`);

--- a/testdata/featuresTests/invalidJavaScriptCode/index.html
+++ b/testdata/featuresTests/invalidJavaScriptCode/index.html
@@ -1,0 +1,14 @@
+<!doctype html>
+<html>
+
+<head>
+</head>
+
+<body>
+  <h1>Invalid JavaScript code</h1>
+  <script src="app.js"></script>
+  <button id='runCode' onclick="runCode()">Click me</button>
+  <p id='#pageLoadedSuccesfully'>Page loaded succesfully</p>
+</body>
+
+</html>


### PR DESCRIPTION
We test that we show an error in the console/output when we parse an invalid JavaScript file.

Validates bug fixed by: https://github.com/microsoft/vscode-chrome-debug-core/pull/475

Currently the test will already pass because we added asyncUndefinedOnFailure to CDTPExceptionThrownEventsProvider.toExceptionDetails because we get invalid script ids when we attach. With this updated code, instead of returning undefined, we'll return the actual reference to the script.