### PR TITLE
Fix startup telemetry

### DIFF
--- a/src/chromeDebug.ts
+++ b/src/chromeDebug.ts
@@ -14,6 +14,7 @@ import { HTMLSourceRetriever } from './components/htmlSourceLogic';
 import { CDTPResourceContentGetter } from './cdtpComponents/cdtpResourceContentGetter';
 import { ShowOverlayWhenPaused, CDTPDeprecatedPage } from './features/showOverlayWhenPaused';
 import { CustomizedUninitializedCDA } from './components/customizedUninitializedCDA';
+import { ReportVersionInformation } from './features/reportVersionInformation';
 
 const EXTENSION_NAME = 'debugger-for-chrome';
 
@@ -42,6 +43,7 @@ extensibilityPoints.targetFilter = defaultTargetFilter;
 extensibilityPoints.pathTransformer = UrlPathTransformer;
 extensibilityPoints.bindAdditionalComponents = (diContainer: DependencyInjection) => {
     diContainer.configureClass(TYPES.IServiceComponent, ShowOverlayWhenPaused);
+    diContainer.configureClass(TYPES.IServiceComponent, ReportVersionInformation);
     diContainer.configureClass(CDTPDeprecatedPage, CDTPDeprecatedPage);
 };
 

--- a/test/chromeDebugAdapter.test.ts
+++ b/test/chromeDebugAdapter.test.ts
@@ -5,7 +5,7 @@
 import * as assert from 'assert';
 import * as mockery from 'mockery';
 import { IMock, It, Mock, MockBehavior, Times } from 'typemoq';
-import { chromeConnection, ISourceMapPathOverrides, TargetVersions, Version } from 'vscode-chrome-debug-core';
+import { chromeConnection, ISourceMapPathOverrides, TargetVersions, Version, ExecutionTimingsReporter } from 'vscode-chrome-debug-core';
 import { DebugProtocol } from 'vscode-debugprotocol';
 import { ChromeDebugAdapter as _ChromeDebugAdapter } from '../src/chromeDebugAdapter';
 import { getMockChromeConnectionApi, IMockChromeConnectionAPI } from './debugProtocolMocks';
@@ -33,7 +33,8 @@ suite('ChromeDebugAdapter', () => {
         mockery.enable({ useCleanCache: true, warnOnReplace: false, warnOnUnregistered: false });
 
         // Create a ChromeConnection mock with .on and .attach. Tests can fire events via mockEventEmitter
-        mockChromeConnection = Mock.ofType(chromeConnection.ChromeConnection, MockBehavior.Strict, false, {events: {}}, {}, { extensibilityPoints: {}});
+        mockChromeConnection = Mock.ofType(chromeConnection.ChromeConnection, MockBehavior.Strict, false, {events: {}}, {},
+             new ExecutionTimingsReporter(), { extensibilityPoints: {}});
         mockChrome = getMockChromeConnectionApi();
         mockChromeDebugSession = Mock.ofType(MockChromeDebugSession, MockBehavior.Strict);
         mockChromeDebugSession


### PR DESCRIPTION
chromeDebug.ts, reportVersionInformation.ts: ReportVersionInformation wasn't been initialized
chromeLauncher.ts: Migrate telemetry to v2 format, and restore some deleted steps

This PR is part of this change: https://github.com/microsoft/vscode-chrome-debug-core/pull/479