### PR TITLE
Improve telemetry

### DIFF
--- a/src/features/reportVersionInformation.ts
+++ b/src/features/reportVersionInformation.ts
@@ -2,7 +2,8 @@
  * Copyright (C) Microsoft Corporation. All rights reserved.
  *--------------------------------------------------------*/
 import {
-    utils as coreUtils, logger, telemetry, inject, TYPES, IDebuggeeStateInspector, ConnectedCDAConfiguration, INetworkCacheConfigurer, IDebuggeeRuntimeVersionProvider, IServiceComponent, injectable,
+    utils as coreUtils, logger, telemetry, inject, TYPES, IDebuggeeStateInspector, ConnectedCDAConfiguration,
+    INetworkCacheConfigurer, IDebuggeeRuntimeVersionProvider, injectable, IServiceComponent
 } from 'vscode-chrome-debug-core';
 import { ICommonRequestArgs } from '../chromeDebugInterfaces';
 
@@ -109,5 +110,9 @@ export class ReportVersionInformation implements IServiceComponent {
         @inject(TYPES.ConnectedCDAConfiguration) private readonly _configuration: ConnectedCDAConfiguration,
         @inject(TYPES.INetworkCacheConfiguration) private readonly _networkCacheConfiguration: INetworkCacheConfigurer,
         @inject(TYPES.IDebuggeeRuntimeVersionProvider) private readonly _debugeeVersionProvider: IDebuggeeRuntimeVersionProvider) {
+    }
+
+    public toString(): string {
+        return 'ReportVersionInformation';
     }
 }

--- a/src/features/showOverlayWhenPaused.ts
+++ b/src/features/showOverlayWhenPaused.ts
@@ -2,7 +2,10 @@
  * Copyright (C) Microsoft Corporation. All rights reserved.
  *--------------------------------------------------------*/
 import * as utils from '../utils';
-import { CDTP, ISupportedDomains, inject, TYPES, CDTPEventsEmitterDiagnosticsModule, IServiceComponent, ConnectedCDAConfiguration, CDTPDomainsEnabler, IPausedOverlayConfigurer, ICDTPDebuggeeExecutionEventsProvider, injectable } from 'vscode-chrome-debug-core';
+import {
+    CDTP, ISupportedDomains, inject, TYPES, CDTPEventsEmitterDiagnosticsModule, IServiceComponent, ConnectedCDAConfiguration,
+    CDTPDomainsEnabler, IPausedOverlayConfigurer, ICDTPDebuggeeExecutionEventsProvider, injectable
+} from 'vscode-chrome-debug-core';
 import { ILaunchRequestArgs } from '../chromeDebugInterfaces';
 
 // TODO: This is a deprecated page method. We should migrate this to Overlay.setPausedInDebuggerMessage
@@ -77,5 +80,9 @@ export class ShowOverlayWhenPaused implements IServiceComponent {
 
     public install(): this {
         return this;
+    }
+
+    public toString(): string {
+        return 'ShowOverlayWhenPaused';
     }
 }

--- a/src/launcherAndRuner/chromeRunner.ts
+++ b/src/launcherAndRuner/chromeRunner.ts
@@ -34,7 +34,9 @@ export class ChromeRunner implements IDebuggeeRunner {
                  */
             });
         }
+    }
 
+    public async waitUntilRunning(): Promise<void> {
         return this._userPageLaunched.promise;
     }
 

--- a/test/int/featureBasedSuits/loadedSources.test.ts
+++ b/test/int/featureBasedSuits/loadedSources.test.ts
@@ -16,7 +16,10 @@ let loadedSources: DebugProtocol.Source[] = [];
 function onLoadedSource(args: DebugProtocol.LoadedSourceEvent): void {
     switch (args.body.reason) {
         case 'new':
-            loadedSources.push(args.body.source);
+            // We ignore scripts added by puppeteer
+            if (args.body.source.name !== '__puppeteer_evaluation_script__') {
+                    loadedSources.push(args.body.source);
+            }
             break;
         case 'changed':
         case 'removed':


### PR DESCRIPTION
Added toString to objects that get reported in the startup timings telemetry.

Created the method waitUntilRunning in ChromeRunner to make chrome-debug compatible with this change in -core:  https://github.com/microsoft/vscode-chrome-debug-core/pull/486