### PR TITLE
Skip hit count bp invalid condition

### DIFF
--- a/test/int/featureBasedSuits/hitCountBreakpointsDifferentOperators.test.ts
+++ b/test/int/featureBasedSuits/hitCountBreakpointsDifferentOperators.test.ts
@@ -109,7 +109,7 @@ puppeteerSuite('Hit count breakpoints combinations', reactWithLoopTestSpecificat
     ];
 
     manyInvalidConditions.forEach(invalidCondition => {
-        puppeteerTest(`invalid condition ${invalidCondition}`, suiteContext, async () => {
+        puppeteerTest.skip(`invalid condition ${invalidCondition}`, suiteContext, async () => {
             const breakpoints = BreakpointsWizard.create(suiteContext.debugClient, reactWithLoopTestSpecification);
             const counterBreakpoints = breakpoints.at('Counter.jsx');
 


### PR DESCRIPTION
These tests test a behavior that is wrong (setBreakpoint fails when an invalid hit count condition is supplied).
I'm temporarily disabling these tests until we merge the PR that makes setBreakpoint behave properly