### PR TITLE
Multiple breakpoints test and fix existing test

### DIFF
--- a/test/int/featureBasedSuits/hitCountBreakpointsDifferentOperators.test.ts
+++ b/test/int/featureBasedSuits/hitCountBreakpointsDifferentOperators.test.ts
@@ -12,7 +12,6 @@ import * as _ from 'lodash';
 import { puppeteerSuite, puppeteerTest } from '../puppeteer/puppeteerSuite';
 import { reactWithLoopTestSpecification } from '../resources/resourceProjects';
 import { BreakpointsWizard as BreakpointsWizard } from '../wizards/breakpoints/breakpointsWizard';
-import { expect } from 'chai';
 import { logger } from 'vscode-debugadapter';
 
 puppeteerSuite('Hit count breakpoints combinations', reactWithLoopTestSpecification, (suiteContext) => {
@@ -94,33 +93,25 @@ puppeteerSuite('Hit count breakpoints combinations', reactWithLoopTestSpecificat
         '= -1',
         '> -200',
         '< -24',
-        '< 64\t',
-        '< 5      ',
         '>= -95',
         '<= -5',
-        '\t= 1',
         '< = 4',
-        '         <= 4',
         '% -200',
         'stop always',
-        '       = 3     ',
         '= 1 + 1',
         '> 3.5',
     ];
 
     manyInvalidConditions.forEach(invalidCondition => {
-        puppeteerTest.skip(`invalid condition ${invalidCondition}`, suiteContext, async () => {
+        puppeteerTest(`invalid condition ${invalidCondition}`, suiteContext, async () => {
             const breakpoints = BreakpointsWizard.create(suiteContext.debugClient, reactWithLoopTestSpecification);
             const counterBreakpoints = breakpoints.at('Counter.jsx');
 
-            try {
-                await counterBreakpoints.hitCountBreakpoint({
-                    text: 'iterationNumber * iterationNumber',
-                    hitCountCondition: invalidCondition
-                });
-            } catch (exception) {
-                expect(exception.toString()).to.be.equal(`Error: [debugger-for-chrome] Error processing "setBreakpoints": Didn't recognize <${invalidCondition}> as a valid hit count condition`);
-            }
+            await counterBreakpoints.unverifiedHitCountBreakpoint({
+                text: 'iterationNumber * iterationNumber',
+                hitCountCondition: invalidCondition,
+                unverifiedReason: `Didn't recognize <${invalidCondition}> as a valid hit count condition`
+            });
         });
     });
 });

--- a/test/int/featureBasedSuits/multipleBreakpoints.test.ts
+++ b/test/int/featureBasedSuits/multipleBreakpoints.test.ts
@@ -1,0 +1,40 @@
+import { puppeteerSuite, puppeteerTest } from '../puppeteer/puppeteerSuite';
+
+import { reactTestSpecification } from '../resources/resourceProjects';
+import { BreakpointsWizard } from '../wizards/breakpoints/breakpointsWizard';
+
+puppeteerSuite('Multiple breakpoints on a React project', reactTestSpecification, (suiteContext) => {
+    puppeteerTest('Can hit two valid breakpoints, while we set them with an invalid hit count breakpoints', suiteContext, async (_context, page) => {
+        const incBtn = await page.waitForSelector('#incrementBtn');
+
+        const breakpoints = BreakpointsWizard.create(suiteContext.debugClient, reactTestSpecification);
+        const counterBreakpoints = breakpoints.at('Counter.jsx');
+
+        const { setStateBreakpoint, setNewValBreakpoint } = await counterBreakpoints.batch(async () => ({
+            stepInBreakpoint: (await (await counterBreakpoints.unsetHitCountBreakpoint({
+                text: 'this.stepIn();',
+                boundText: 'stepIn()',
+                hitCountCondition: 'bad bad hit count breakpoint condition = 2'
+            })).setWithoutVerifying()), // We want the invalid condition to be first to see that the other 2 breakpoints are actually set
+
+            setNewValBreakpoint: await counterBreakpoints.breakpoint({
+                text: 'const newval = this.state.count + 1',
+                boundText: 'state.count + 1'
+            }),
+
+            setStateBreakpoint: await counterBreakpoints.breakpoint({
+                text: 'this.setState({ count: newval });',
+                boundText: 'setState({ count: newval })'
+            }),
+        }));
+
+        await breakpoints.assertIsHitThenResumeWhen([setNewValBreakpoint, setStateBreakpoint], () => incBtn.click(), {});
+
+        await breakpoints.waitAndAssertNoMoreEvents();
+
+        await counterBreakpoints.batch(async () => {
+            await setStateBreakpoint.unset();
+            await setNewValBreakpoint.unset();
+        });
+    });
+});

--- a/test/int/featureBasedSuits/multipleBreakpoints.test.ts
+++ b/test/int/featureBasedSuits/multipleBreakpoints.test.ts
@@ -1,3 +1,8 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
 import { puppeteerSuite, puppeteerTest } from '../puppeteer/puppeteerSuite';
 
 import { reactTestSpecification } from '../resources/resourceProjects';

--- a/test/int/wizards/breakpoints/breakpointWizard.ts
+++ b/test/int/wizards/breakpoints/breakpointWizard.ts
@@ -3,14 +3,18 @@ import { IBPActionWhenHit } from '../../core-v2/chrome/internal/breakpoints/bpAc
 import { InternalFileBreakpointsWizard } from './implementation/internalFileBreakpointsWizard';
 import { RemoveProperty } from '../../core-v2/typeUtils';
 import { DebugProtocol } from 'vscode-debugprotocol';
-import { IVerificationsAndAction } from './implementation/breakpointsAssertions';
+import { IVerificationsAndAction } from './breakpointsWizard';
 
 export class BreakpointWizard {
-    private _state: IBreakpointSetOrUnsetState = new BreakpointUnsetState(this, this._internal, this.changeStateFunction());
+    private isBreakpointSet = false;
 
     public constructor(
         private readonly _internal: InternalFileBreakpointsWizard, public readonly position: Position,
         public readonly actionWhenHit: IBPActionWhenHit, public readonly name: string, public readonly boundPosition: Position) { }
+
+    public get filePath(): string {
+        return this._internal.filePath;
+    }
 
     public async setThenWaitForVerifiedThenValidate(): Promise<BreakpointWizard> {
         await this.setWithoutVerifying();
@@ -20,130 +24,66 @@ export class BreakpointWizard {
     }
 
     public async waitUntilVerified(): Promise<BreakpointWizard> {
-        await this._state.waitUntilVerified();
-        return this;
+        this.validateIsSet('waitUntilVerified');
+        await this._internal.waitUntilVerified(this);
+        return Promise.resolve(this);
     }
 
     public async setWithoutVerifying(): Promise<BreakpointWizard> {
-        await this._state.set();
-        return this;
+        this.validateIsUnset('setWithoutVerifying');
+        await this._internal.set(this);
+        this.isBreakpointSet = true;
+        return Promise.resolve(this);
     }
 
     public async unset(): Promise<BreakpointWizard> {
-        await this._state.unset();
-        return this;
+        this.validateIsSet('unset');
+        await this._internal.unset(this);
+        this.isBreakpointSet = false;
+        return Promise.resolve(this);
     }
 
     public async assertIsHitThenResumeWhen(lastActionToMakeBreakpointHit: () => Promise<unknown>, verifications: IVerificationsAndAction = {}): Promise<BreakpointWizard> {
-        await this._state.assertIsHitThenResumeWhen(lastActionToMakeBreakpointHit, verifications);
-        return this;
+        this.validateIsSet('assertIsHitThenResumeWhen');
+        await this._internal.assertIsHitThenResumeWhen(this, lastActionToMakeBreakpointHit, verifications);
+        return Promise.resolve(this);
     }
 
-    public async assertIsHitThenResume(verifications: IVerificationsAndAction) {
-        await this._state.assertIsHitThenResume(verifications);
-        return this;
+    public async assertIsHitThenResume(verifications: IVerificationsAndAction): Promise<BreakpointWizard> {
+        this.validateIsSet('assertIsHitThenResume');
+        await this._internal.assertIsHitThenResume(this, verifications);
+        return Promise.resolve(this);
     }
 
     public assertIsVerified(): this {
-        this._state.assertIsVerified();
+        this.validateIsSet('assertIsVerified');
+        this._internal.assertIsVerified(this);
         return this;
     }
 
-    private changeStateFunction(): ChangeBreakpointWizardState {
-        return newState => this._state = newState;
+    public assertIsNotVerified(unverifiedReason: string): this {
+        this.validateIsSet('assertIsNotVerified');
+        this._internal.assertIsNotVerified(this, unverifiedReason);
+        return this;
     }
 
     public toString(): string {
         return this.name;
     }
+
+    private validateIsSet(operationName: string): void {
+        this.validateInExpectedState(true, operationName);
+    }
+
+    private validateIsUnset(operationName: string): void {
+        this.validateInExpectedState(false, operationName);
+    }
+
+    private validateInExpectedState(needsToBeSet: boolean, operationName: string): void {
+        if (this.isBreakpointSet !== needsToBeSet) {
+            throw new Error(`Can't perform operation ${operationName} because it needs breakpoint to ${needsToBeSet ? '' : 'NOT '} be set`);
+        }
+    }
 }
 
 export type VSCodeActionWhenHit = RemoveProperty<DebugProtocol.SourceBreakpoint, 'line' | 'column'>;
-
-export type ChangeBreakpointWizardState = (newState: IBreakpointSetOrUnsetState) => void;
-
-export interface IBreakpointSetOrUnsetState {
-    set(): Promise<void>;
-    unset(): Promise<void>;
-    assertIsHitThenResumeWhen(lastActionToMakeBreakpointHit: () => Promise<unknown>, verifications: IVerificationsAndAction): Promise<void>;
-    assertIsHitThenResume(verifications: IVerificationsAndAction): Promise<void>;
-    assertIsVerified(): void;
-    waitUntilVerified(): Promise<void>;
-}
-
-class BreakpointSetState implements IBreakpointSetOrUnsetState {
-    public constructor(
-        private readonly _breakpoint: BreakpointWizard,
-        private readonly _internal: InternalFileBreakpointsWizard,
-        private readonly _changeState: ChangeBreakpointWizardState) {
-    }
-
-    public set(): Promise<void> {
-        throw new Error(`Can't set a breakpoint that is already set`);
-    }
-
-    public async unset(): Promise<void> {
-        await this._internal.unset(this._breakpoint);
-        this._changeState(new BreakpointUnsetState(this._breakpoint, this._internal, this._changeState));
-    }
-
-    /**
-     * This method is intended to avoid hangs when performing a puppeteer action that will get blocked while the debuggee hits a breakpoint.
-     *
-     * The method will execute the puppeteer action, verify that the breakpoint is hit, and afterwards verify that the puppeteer action was properly finished.
-     *
-     * More details:
-     * The method will also verify that the pause was in the exact locatio that the breakpoint is located, and any other verifications specified in the verifications parameter
-     */
-    public assertIsHitThenResumeWhen(lastActionToMakeBreakpointHit: () => Promise<void>, verifications: IVerificationsAndAction): Promise<void> {
-        return this._internal.assertIsHitThenResumeWhen(this._breakpoint, lastActionToMakeBreakpointHit, verifications);
-    }
-
-    /**
-     * Verify that the debuggee is paused due to this breakpoint, and perform a customizable list of extra verifications
-     */
-    public assertIsHitThenResume(verifications: IVerificationsAndAction): Promise<void> {
-        return this._internal.assertIsHitThenResume(this._breakpoint, verifications);
-    }
-
-    public assertIsVerified(): void {
-        this._internal.assertIsVerified(this._breakpoint);
-    }
-
-    public async waitUntilVerified(): Promise<void> {
-        await this._internal.waitUntilVerified(this._breakpoint);
-    }
-}
-
-export class BreakpointUnsetState implements IBreakpointSetOrUnsetState {
-    public constructor(
-        private readonly _breakpoint: BreakpointWizard,
-        private readonly _internal: InternalFileBreakpointsWizard,
-        private readonly _changeState: ChangeBreakpointWizardState) {
-    }
-
-    public async set(): Promise<void> {
-        await this._internal.set(this._breakpoint);
-        this._changeState(new BreakpointSetState(this._breakpoint, this._internal, this._changeState));
-    }
-
-    public unset(): Promise<void> {
-        throw new Error(`Can't unset a breakpoint that is already unset`);
-    }
-
-    public assertIsHitThenResumeWhen(_lastActionToMakeBreakpointHit: () => Promise<void>, _verifications: IVerificationsAndAction): Promise<void> {
-        throw new Error(`Can't expect to hit a breakpoint that is unset`);
-    }
-
-    public assertIsHitThenResume(_verifications: IVerificationsAndAction): Promise<void> {
-        throw new Error(`Can't expect to hit a breakpoint that is unset`);
-    }
-
-    public assertIsVerified(): never {
-        throw new Error(`Can't expect an unset breakpoint to be verified`);
-    }
-
-    public async waitUntilVerified(): Promise<void> {
-        throw new Error(`Can't expect an unset breakpoint to ever become verified`);
-    }
-}

--- a/test/int/wizards/breakpoints/fileBreakpointsWizard.ts
+++ b/test/int/wizards/breakpoints/fileBreakpointsWizard.ts
@@ -13,6 +13,15 @@ export interface IHitCountBreakpointOptions extends IBreakpointOptions {
     hitCountCondition: string;
 }
 
+export interface IUnverifiedBreakpointOptions {
+    text: string;
+    unverifiedReason: string;
+}
+
+export interface IUnverifiedHitCountBreakpointOptions extends IUnverifiedBreakpointOptions {
+    hitCountCondition: string;
+}
+
 export class FileBreakpointsWizard {
     public constructor(private readonly _internal: InternalFileBreakpointsWizard) { }
 
@@ -28,6 +37,10 @@ export class FileBreakpointsWizard {
 
     public async hitCountBreakpoint(options: IHitCountBreakpointOptions): Promise<BreakpointWizard> {
         return (await (await this.unsetHitCountBreakpoint(options)).setThenWaitForVerifiedThenValidate());
+    }
+
+    public async unverifiedHitCountBreakpoint(options: IUnverifiedHitCountBreakpointOptions): Promise<BreakpointWizard> {
+        return (await (await this.unsetHitCountBreakpoint(options)).setWithoutVerifying()).assertIsNotVerified(options.unverifiedReason);
     }
 
     public async unsetHitCountBreakpoint(options: IHitCountBreakpointOptions): Promise<BreakpointWizard> {

--- a/test/int/wizards/breakpoints/implementation/batchingUpdatesState.ts
+++ b/test/int/wizards/breakpoints/implementation/batchingUpdatesState.ts
@@ -10,7 +10,7 @@ import { ValidatedSet } from '../../../core-v2/chrome/collections/validatedSet';
 import {
     IBreakpointsBatchingStrategy, InternalFileBreakpointsWizard, CurrentBreakpointsMapping, BreakpointsUpdate, BreakpointStatusChangedWithId
 } from './internalFileBreakpointsWizard';
-import { IVerificationsAndAction } from './breakpointsAssertions';
+import { IVerificationsAndAction } from '../breakpointsWizard';
 
 export class BatchingUpdatesState implements IBreakpointsBatchingStrategy {
     private readonly _breakpointsToSet = new ValidatedSet<BreakpointWizard>();
@@ -31,6 +31,10 @@ export class BatchingUpdatesState implements IBreakpointsBatchingStrategy {
 
     public assertIsVerified(breakpoint: BreakpointWizard): void {
         this._actionsToCompleteAfterBatch.push(() => this._internal.assertIsVerified(breakpoint));
+    }
+
+    public assertIsNotVerified(breakpoint: BreakpointWizard, unverifiedReason: string): void {
+        this._actionsToCompleteAfterBatch.push(() => this._internal.assertIsNotVerified(breakpoint, unverifiedReason));
     }
 
     public async waitUntilVerified(breakpoint: BreakpointWizard): Promise<void> {

--- a/test/int/wizards/breakpoints/implementation/internalFileBreakpointsWizard.ts
+++ b/test/int/wizards/breakpoints/implementation/internalFileBreakpointsWizard.ts
@@ -14,9 +14,8 @@ import { PromiseOrNot } from 'vscode-chrome-debug-core';
 import { BatchingUpdatesState } from './batchingUpdatesState';
 import { PerformChangesImmediatelyState } from './performChangesImmediatelyState';
 import { BreakpointsUpdater } from './breakpointsUpdater';
-import { BreakpointsWizard } from '../breakpointsWizard';
+import { BreakpointsWizard, IVerificationsAndAction } from '../breakpointsWizard';
 import { MakePropertyRequired, Replace } from '../../../core-v2/typeUtils';
-import { IVerificationsAndAction } from './breakpointsAssertions';
 
 export type BreakpointWithId = MakePropertyRequired<DebugProtocol.Breakpoint, 'id'>;
 export type BreakpointStatusChangedWithId = Replace<DebugProtocol.BreakpointEvent['body'], 'breakpoint', BreakpointWithId>;
@@ -36,7 +35,8 @@ export interface IBreakpointsBatchingStrategy {
 
     waitUntilVerified(breakpoint: BreakpointWizard): Promise<void>;
     assertIsVerified(breakpoint: BreakpointWizard): void;
-    assertIsHitThenResumeWhen(breakpoint: BreakpointWizard, lastActionToMakeBreakpointHit: () => Promise<void>, verifications: IVerificationsAndAction): Promise<void>;
+    assertIsNotVerified(breakpoint: BreakpointWizard, unverifiedReason: string): void;
+    assertIsHitThenResumeWhen(breakpoint: BreakpointWizard, lastActionToMakeBreakpointHit: () => Promise<unknown>, verifications: IVerificationsAndAction): Promise<void>;
     assertIsHitThenResume(breakpoint: BreakpointWizard, verifications: IVerificationsAndAction): Promise<void>;
 
     onBreakpointStatusChange(breakpointStatusChanged: BreakpointStatusChangedWithId): void;
@@ -77,7 +77,11 @@ export class InternalFileBreakpointsWizard {
         this._state.assertIsVerified(breakpoint);
     }
 
-    public async assertIsHitThenResumeWhen(breakpoint: BreakpointWizard, lastActionToMakeBreakpointHit: () => Promise<void>, verifications: IVerificationsAndAction): Promise<void> {
+    public assertIsNotVerified(breakpoint: BreakpointWizard, unverifiedReason: string) {
+        this._state.assertIsNotVerified(breakpoint, unverifiedReason);
+    }
+
+    public async assertIsHitThenResumeWhen(breakpoint: BreakpointWizard, lastActionToMakeBreakpointHit: () => Promise<unknown>, verifications: IVerificationsAndAction): Promise<void> {
         return this._state.assertIsHitThenResumeWhen(breakpoint, lastActionToMakeBreakpointHit, verifications);
     }
 

--- a/test/int/wizards/breakpoints/implementation/performChangesImmediatelyState.ts
+++ b/test/int/wizards/breakpoints/implementation/performChangesImmediatelyState.ts
@@ -6,12 +6,12 @@
 import { BreakpointWizard } from '../breakpointWizard';
 import { ValidatedMap } from '../../../core-v2/chrome/collections/validatedMap';
 import { IBreakpointsBatchingStrategy, InternalFileBreakpointsWizard, CurrentBreakpointsMapping, BreakpointsUpdate, BreakpointStatusChangedWithId } from './internalFileBreakpointsWizard';
-import { BreakpointsAssertions, IVerificationsAndAction } from './breakpointsAssertions';
-import { BreakpointsWizard } from '../breakpointsWizard';
+import { BreakpointsAssertions } from './breakpointsAssertions';
+import { BreakpointsWizard, IVerificationsAndAction } from '../breakpointsWizard';
 
 export class PerformChangesImmediatelyState implements IBreakpointsBatchingStrategy {
     private readonly _idToBreakpoint = new ValidatedMap<number, BreakpointWizard>();
-    private readonly _breakpointsAssertions = new BreakpointsAssertions(this._breakpointsWizard, this._internal, this.currentBreakpointsMapping);
+    private readonly _breakpointsAssertions = new BreakpointsAssertions(this._internal, this.currentBreakpointsMapping);
 
     public constructor(
         private readonly _breakpointsWizard: BreakpointsWizard,
@@ -48,16 +48,20 @@ export class PerformChangesImmediatelyState implements IBreakpointsBatchingStrat
         this._breakpointsAssertions.assertIsVerified(breakpoint);
     }
 
+    public assertIsNotVerified(breakpoint: BreakpointWizard, unverifiedReason: string): void {
+        this._breakpointsAssertions.assertIsNotVerified(breakpoint, unverifiedReason);
+    }
+
     public async waitUntilVerified(breakpoint: BreakpointWizard): Promise<void> {
         await this._breakpointsAssertions.waitUntilVerified(breakpoint);
     }
 
     public async assertIsHitThenResumeWhen(breakpoint: BreakpointWizard, lastActionToMakeBreakpointHit: () => Promise<void>, verifications: IVerificationsAndAction): Promise<void> {
-        await this._breakpointsAssertions.assertIsHitThenResumeWhen(breakpoint, lastActionToMakeBreakpointHit, verifications);
+        await this._breakpointsWizard.assertIsHitThenResumeWhen([breakpoint], lastActionToMakeBreakpointHit, verifications);
     }
 
     public async assertIsHitThenResume(breakpoint: BreakpointWizard, verifications: IVerificationsAndAction): Promise<void> {
-        await this._breakpointsAssertions.assertIsHitThenResume(breakpoint, verifications);
+        await this._breakpointsWizard.assertIsHitThenResume(breakpoint, verifications);
     }
 
     private currentBreakpoints(): BreakpointWizard[] {


### PR DESCRIPTION
* hitCountBreakpointsDifferentOperators.test.ts:
1. Removed some invalid conditions that are actually valid. The test passed before because we were doing a try {} catch { assert() } so we didn't throw an exception and the test passed for the valid conditions
2. Originally this test was testing that setBreakpoint fails when a condition is invalid. Changed it to expect setBreakpoints to succeed and return a non verified

* multipleBreakpoints.test.ts: New test verifying that if we set 3 breakpoints and 1 is invalid, the other 2 are set and hit correctly

* breakpointWizard.ts: Added the assertIsNotVerified method. Also removed the state pattern to simplify the code as part of this change.

* breakpointsWizard.ts: Moved the methods assertIsHitThenResumeWhen and assertIsHitThenResume from breakpointsAssertions.ts to add support for multiple breakpoints

* fileBreakpointsWizard.ts: Added method to set an unverified hit count breakpoint

* batchingUpdatesState.ts: Added support for assertIsNotVerified

* breakpointsAssertions.ts: 
1. Moved assertIsHitThenResumeWhen and assertIsHitThenResume to breakpointsWizard.ts.
2. Changed assertLocationMatchesExpected to a exported function assertMatchesBreakpointLocation so we can call it from breakpointsWizard.ts
3. Added assertIsNotVerified
