### PR TITLE
Use taskkill to kill Chrome in Windows by default

### DIFF
--- a/src/launcherAndRuner/chromeLauncher.ts
+++ b/src/launcherAndRuner/chromeLauncher.ts
@@ -300,7 +300,11 @@ export class ChromeLauncher implements IDebuggeeLauncher {
 
             const _chromePID = chromeProc.pid;
 
-            return new LaunchedAsChildProcess(_chromePID, chromeProc);
+            if (platform === coreUtils.Platform.Windows && _chromePID) {
+                return new LaunchedInWindowsWithPID(_chromePID);
+            } else {
+                return new LaunchedAsChildProcess(_chromePID, chromeProc);
+            }
         }
     }
 


### PR DESCRIPTION
LaunchedInWindowsWithPID uses taskkill which seems to result in less "Chrome wasn't closed properly, do you want to restore tabs" message. We now use LaunchedInWindowsWithPID by default on Windows