### PR TITLE
Now we don't send sourceReference if we can't retrieve the source

### DIFF
--- a/src/cdtpComponents/cdtpResourceContentGetter.ts
+++ b/src/cdtpComponents/cdtpResourceContentGetter.ts
@@ -1,7 +1,7 @@
 /*---------------------------------------------------------
  * Copyright (C) Microsoft Corporation. All rights reserved.
  *--------------------------------------------------------*/
-import { TYPES, inject, injectable, CDTPEnableableDiagnosticsModule, CDTP, CDTPDomainsEnabler, IExecutionContextEventsProvider } from 'vscode-chrome-debug-core';
+import { TYPES, inject, injectable, CDTPEnableableDiagnosticsModule, CDTP, CDTPDomainsEnabler, IExecutionContextEventsProvider, SourceContents } from 'vscode-chrome-debug-core';
 import * as _ from 'lodash';
 
 /**
@@ -34,7 +34,7 @@ export class CDTPResourceContentGetter extends CDTPEnableableDiagnosticsModule<C
     });
     }
 
-    public async resourceContent(params: CDTP.Page.GetResourceContentRequest): Promise<string> {
-        return (await this.api.getResourceContent(params)).content;
+    public async resourceContent(params: CDTP.Page.GetResourceContentRequest): Promise<SourceContents> {
+        return new SourceContents((await this.api.getResourceContent(params)).content);
     }
 }

--- a/src/components/htmlSourceLogic.ts
+++ b/src/components/htmlSourceLogic.ts
@@ -1,46 +1,33 @@
 /*---------------------------------------------------------
  * Copyright (C) Microsoft Corporation. All rights reserved.
  *--------------------------------------------------------*/
-import { ISource, ILoadedSourceTreeNode, IScript, SourceScriptRelationship, utilities, ISourcesRetriever, SourceContents } from 'vscode-chrome-debug-core';
+import {
+    SourceScriptRelationship, utilities, GetSourceTextRetrievability, IScriptSourcesRetriever,
+    IPossiblyRetrievableText, ILoadedSource, RetrievableText, NonRetrievableText,
+} from 'vscode-chrome-debug-core';
 import { CDTPResourceContentGetter } from '../cdtpComponents/cdtpResourceContentGetter';
 import * as _ from 'lodash';
 
 /**
  * We use our own version of the ISourcesRetriever component which adds support for getting the source of .html files with potentially multiple inline scripts
  */
-export class HTMLSourceRetriever implements ISourcesRetriever {
-    constructor(
-        private readonly _wrappedSourcesLogic: ISourcesRetriever,
-        private readonly _resourceContentGetter: CDTPResourceContentGetter) { }
+export function retrievabilityWithHTMLSupport(
+    wrappedRetrievability: GetSourceTextRetrievability, scriptSources: IScriptSourcesRetriever,
+    resourceContentGetter: CDTPResourceContentGetter, loadedSource: ILoadedSource): IPossiblyRetrievableText {
+    const existingRetrievability = wrappedRetrievability(scriptSources, loadedSource);
 
-    public loadedSourcesTrees(): Promise<ILoadedSourceTreeNode[]> {
-        return this._wrappedSourcesLogic.loadedSourcesTrees();
+    if (!existingRetrievability.isRetrievable && loadedSource.sourceScriptRelationship === SourceScriptRelationship.SourceIsMoreThanAScript) {
+        const frameIds = _.uniq(loadedSource.scriptMapper().scripts.map(script => script.executionContext.frameId));
+
+        // For the time being we don't support iframes, so we assume that there is a single frameId in that collection
+        if (frameIds.length > 1) {
+            return new NonRetrievableText(() => {
+                throw new Error(`iFrames are not currently supported. frame ids: ${JSON.stringify(frameIds)}`);
+            });
+        }
+
+        return new RetrievableText(() => resourceContentGetter.resourceContent({ url: loadedSource.url, frameId: utilities.singleElementOfArray(frameIds) }));
     }
 
-    public loadedSourcesTreeForScript(script: IScript): ILoadedSourceTreeNode {
-        return this._wrappedSourcesLogic.loadedSourcesTreeForScript(script);
-    }
-
-    public async text(source: ISource): Promise<SourceContents> {
-        return source.tryResolving(
-            async loadedSource => {
-                if (loadedSource.sourceScriptRelationship === SourceScriptRelationship.SourceIsMoreThanAScript) {
-                    const frameIds = _.uniq(loadedSource.scriptMapper().scripts.map(script => script.executionContext.frameId));
-
-                    // For the time being we don't support iframes, so we assume that there is a single frameId in that collection
-                    if (frameIds.length > 1) {
-                        throw new Error(`iFrames are not currently supported. frame ids: ${JSON.stringify(frameIds)}`);
-                    }
-
-                    const contents = await this._resourceContentGetter.resourceContent({ url: loadedSource.url, frameId: utilities.singleElementOfArray(frameIds) });
-                    return new SourceContents(contents);
-                }
-                return this._wrappedSourcesLogic.text(source);
-            },
-            () => this._wrappedSourcesLogic.text(source));
-    }
-
-    public async install(): Promise<this> {
-        return this;
-    }
+    return existingRetrievability;
 }


### PR DESCRIPTION
While adding support for getSourceTextRetrievability in https://github.com/microsoft/vscode-chrome-debug-core/pull/527 we created that sub-component for TYPES.ISourcesRetriever.
Now instead of replacing the full TYPES.ISourcesRetriever we just replace the retrievability function TYPES.GetSourceTextRetrievability.

This change won't compile without this -core PR: https://github.com/microsoft/vscode-chrome-debug-core/pull/527