### PR TITLE
Update to vscode-debugadapter with don't print source fix

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6763,12 +6763,19 @@
       }
     },
     "vscode-debugadapter": {
-      "version": "1.34.0",
-      "resolved": "https://registry.npmjs.org/vscode-debugadapter/-/vscode-debugadapter-1.34.0.tgz",
-      "integrity": "sha512-ye11QX9K4QA4TOuJHVusJenTuqh7GrCsLZJ7Gs86spOJ4WTTPd8wFLJBjL5ivkCUln/Tyo4HMkxlLBlTBtHdog==",
+      "version": "1.36.1",
+      "resolved": "https://registry.npmjs.org/vscode-debugadapter/-/vscode-debugadapter-1.36.1.tgz",
+      "integrity": "sha512-9mFiqno0h8p7zTxYM06VdE3f6DnenqxhDWB/WG6ca7aKIY/kzFFkvohsfRtgDl9iPR17a4a/GgB/mruPKe1T/A==",
       "requires": {
         "mkdirp": "^0.5.1",
-        "vscode-debugprotocol": "1.34.0"
+        "vscode-debugprotocol": "1.36.0"
+      },
+      "dependencies": {
+        "vscode-debugprotocol": {
+          "version": "1.36.0",
+          "resolved": "https://registry.npmjs.org/vscode-debugprotocol/-/vscode-debugprotocol-1.36.0.tgz",
+          "integrity": "sha512-F0MfcUkF88TfNf4iQbcmC+K9rA+zsrQpEz1XpTKidy5sMq8sYsJGUadYDGmmktfjRX+S/ebjHgM+YV/2qm6lVQ=="
+        }
       }
     },
     "vscode-debugadapter-testsupport": {

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
   "dependencies": {
     "reflect-metadata": "^0.1.13",
     "vscode-chrome-debug-core": "git+https://github.com/Microsoft/vscode-chrome-debug-core.git#v2",
-    "vscode-debugadapter": "^1.32.1",
+    "vscode-debugadapter": "^1.36.1",
     "vscode-nls": "^4.1.1",
     "vscode-uri": "^1.0.6"
   },


### PR DESCRIPTION
Update to vscode-debugadapter with don't print source fix