### PR TITLE
Fix picker on v3, and use v3 by default

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "ui"
   ],
   "engines": {
-    "vscode": "^1.46.0"
+    "vscode": "^1.47.0"
   },
   "categories": [
     "Debuggers"

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "ui"
   ],
   "engines": {
-    "vscode": "^1.41.0"
+    "vscode": "^1.46.0"
   },
   "categories": [
     "Debuggers"

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -47,7 +47,8 @@ export class ChromeConfigurationProvider implements vscode.DebugConfigurationPro
             return null;
         }
 
-        if (config.request === 'attach') {
+        const v3 = useV3();
+        if (config.request === 'attach' && !v3) {
             const discovery = new Core.chromeTargetDiscoveryStrategy.ChromeTargetDiscovery(
                 new Core.NullLogger(), new Core.telemetry.NullTelemetryReporter());
 
@@ -71,7 +72,7 @@ export class ChromeConfigurationProvider implements vscode.DebugConfigurationPro
 
         resolveRemoteUris(folder, config);
 
-        if (useV3()) {
+        if (v3) {
             folder = folder || (vscode.workspace.workspaceFolders ? vscode.workspace.workspaceFolders[0] : undefined);
             config['__workspaceFolder'] = folder?.uri.fsPath;
             config.type = 'pwa-chrome';

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -95,18 +95,12 @@ function getFsPath(uri: vscode.Uri): string {
 }
 
 function useV3() {
-    return getWithoutDefault('debug.chrome.useV3') ?? getWithoutDefault('debug.javascript.usePreview') ?? isInsiders();
+    return getWithoutDefault('debug.chrome.useV3') ?? getWithoutDefault('debug.javascript.usePreview') ?? true;
 }
 
 function getWithoutDefault<T>(setting: string): T | undefined {
     const info = vscode.workspace.getConfiguration().inspect<T>(setting);
     return info?.workspaceValue ?? info?.globalValue;
-}
-
-function isInsiders() {
-    return vscode.env.uriScheme === 'vscode-insiders'
-        || vscode.env.uriScheme === 'code-oss'
-        || vscode.env.uriScheme === 'vscode-exploration';
 }
 
 function mapRemoteClientUriToInternalPath(remoteUri: vscode.Uri): string {


### PR DESCRIPTION
Fixes https://github.com/microsoft/vscode-js-debug/issues/437